### PR TITLE
Require spaCy NLP for redaction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-docx
 reportlab
 pdfplumber
 spacy
+en-core-web-sm


### PR DESCRIPTION
## Summary
- enforce spaCy and the `en_core_web_sm` model as mandatory runtime dependencies
- always run spaCy NER in the redaction pipeline
- document model requirement in requirements.txt

## Testing
- `python -m py_compile freedact/redaction.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b315b474908325bca3fbea351c4e0b