### PR TITLE
chore: bootstrap Python package, tooling, and tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.yaml]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Python
+__pycache__/
+*.py[cod]
+*.so
+
+# Packaging
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Virtual environments
+.env
+.venv
+venv/
+ENV/
+
+# IDEs and editors
+.vscode/
+.idea/
+*.swp
+
+# macOS
+.DS_Store
+
+# Byte-compiled / optimized / DLL files
+*.pyo
+*.pyd
+
+# Coverage
+.coverage
+*.cover
+coverage.xml
+
+# Pytest cache
+.pytest_cache/
+
+# Hatch
+.hatch/
+
+# Logs
+*.log
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+        language_version: python3.11
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.0
+    hooks:
+      - id: ruff
+        args: [--fix]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team.
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage].
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+Thank you for considering contributing to redactor! To set up a local development environment:
+
+1. Clone the repository and navigate into it.
+2. Install the project in editable mode with development dependencies:
+   ```bash
+   pip install -e .[dev]
+   ```
+3. Run the linters, type checks, and tests:
+   ```bash
+   make check
+   ```
+4. Use `make format` to apply automatic formatting before committing.
+
+Please open pull requests with clear descriptions and ensure that all checks pass.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Project Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: format lint type test check
+
+format:
+	black .
+
+lint:
+	ruff .
+
+type:
+	mypy .
+
+test:
+	pytest -q
+
+check: lint type test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# redactor
+
+The redactor project aims to provide a privacy-first pipeline for sanitizing legal documents before they are shared with cloud-based language models. It replaces sensitive personal and organizational information with deterministic pseudonyms while preserving the technical facts necessary for analysis. The system operates entirely offline by default and relies on open-source tools for detection and replacement of PII. Each modification is auditable so users can trace the origin and rationale for every change. The goal is to ensure zero leakage of personal data, reproducible outputs, and seamless integration into legal workflows. This repository currently contains only the foundational scaffolding; product functionality will be added in future iterations.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "redactor"
+version = "0.1.0"
+description = "Privacy-first Legal Document Redactor"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [{name = "Project Contributors"}]
+requires-python = ">=3.11"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+# [project.scripts]
+# redactor = "redactor.cli:app"
+
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.1.0",
+    "black>=23.0",
+    "mypy>=1.0",
+    "pytest>=7.0",
+]
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+select = ["E", "F", "B", "I"]
+ignore = ["E203"]  # W503 deprecated
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_unused_ignores = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q
+testpaths = tests

--- a/src/redactor/__init__.py
+++ b/src/redactor/__init__.py
@@ -1,0 +1,3 @@
+"""Top-level package for redactor."""
+
+__version__ = "0.1.0"

--- a/src/redactor/cli.py
+++ b/src/redactor/cli.py
@@ -1,0 +1,6 @@
+"""Command-line interface for redactor.
+
+This module will be implemented in future tasks.
+"""
+
+# Placeholder for CLI entry point

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,11 @@
+"""Smoke tests for package import and version."""
+
+import redactor
+
+
+def test_import_package() -> None:
+    assert isinstance(redactor, object)
+
+
+def test_version() -> None:
+    assert redactor.__version__ == "0.1.0"


### PR DESCRIPTION
## Summary
- scaffold `redactor` package with version constant and CLI placeholder
- configure packaging, linting, formatting, typing, and test tooling
- add project docs, contribution guidelines, and basic smoke tests

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools)*
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32630eb5483259d08cc8c66986e9c