### PR TITLE
chore: add project layout with empty modules and documentation scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,27 @@
 
 The redactor project aims to provide a privacy-first pipeline for sanitizing legal documents before they are shared with cloud-based language models. It replaces sensitive personal and organizational information with deterministic pseudonyms while preserving the technical facts necessary for analysis. The system operates entirely offline by default and relies on open-source tools for detection and replacement of PII. Each modification is auditable so users can trace the origin and rationale for every change. The goal is to ensure zero leakage of personal data, reproducible outputs, and seamless integration into legal workflows. This repository currently contains only the foundational scaffolding; product functionality will be added in future iterations.
 
+## Architecture at a glance
+
+### Top-level modules
+- `config`: configuration loading and validation
+- `io`: file readers and writers
+- `preprocess`: text normalization and segmentation
+- `detect`: entity detectors
+- `link`: span linking and coreference resolution
+- `pseudo`: pseudonym generation rules
+- `replace`: building and applying replacements
+- `verify`: post-redaction checks
+- `evaluation`: metrics and test fixtures
+- `utils`: shared helper utilities
+
+### Pipeline stages
+1. **Preprocess** input text
+2. **Detect** sensitive entities
+3. **Link** and resolve entity references
+4. **Generate pseudonyms** for entities
+5. **Plan & apply replacements**
+6. **Verify** redacted output
+7. **Evaluate** performance (optional)
+
+Modules are intentionally empty pending M1-T3 and later tasks.

--- a/src/redactor/cli.py
+++ b/src/redactor/cli.py
@@ -1,6 +1,22 @@
-"""Command-line interface for redactor.
+"""Command-line interface.
 
-This module will be implemented in future tasks.
+Purpose:
+    Provide entry points for running the redaction pipeline from the terminal.
+
+Key responsibilities:
+    - Parse command-line arguments.
+    - Invoke high-level pipeline functions.
+
+Inputs/Outputs:
+    - Inputs: CLI arguments and options.
+    - Outputs: exit codes and console output.
+
+Public contracts (planned):
+    - `main(argv=None)`: Parse args and execute commands.
+
+Notes/Edge cases:
+    - Should minimize startup time and avoid heavy imports when unused.
+
+Dependencies:
+    - `argparse` from standard library.
 """
-
-# Placeholder for CLI entry point

--- a/src/redactor/config/__init__.py
+++ b/src/redactor/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration subpackage for loading defaults and validating user settings."""

--- a/src/redactor/config/defaults.yml
+++ b/src/redactor/config/defaults.yml
@@ -1,0 +1,2 @@
+# Placeholder configuration defaults.
+# Actual values will be defined in M1-T4.

--- a/src/redactor/config/schema.py
+++ b/src/redactor/config/schema.py
@@ -1,0 +1,23 @@
+"""Configuration schema definitions.
+
+Purpose:
+    Define structured configuration models for the redaction pipeline.
+
+Key responsibilities:
+    - Provide schemas for configuration sections (preprocess, detect, etc.).
+    - Validate user-supplied configuration against defaults.
+
+Inputs/Outputs:
+    - Inputs: raw configuration data as dictionaries or YAML text.
+    - Outputs: validated configuration objects.
+
+Public contracts (planned):
+    - `load_defaults()`: Load default configuration values.
+    - `validate(config_data)`: Validate user configuration and merge with defaults.
+
+Notes/Edge cases:
+    - Schema versioning must be handled to avoid breaking changes.
+
+Dependencies:
+    - `pydantic` (optional for validation).
+"""

--- a/src/redactor/detect/__init__.py
+++ b/src/redactor/detect/__init__.py
@@ -1,0 +1,1 @@
+"""Entity detection components for identifying sensitive information."""

--- a/src/redactor/detect/account_ids.py
+++ b/src/redactor/detect/account_ids.py
@@ -1,0 +1,22 @@
+"""Account identifier detector.
+
+Purpose:
+    Detect bank or credit account numbers in text.
+
+Key responsibilities:
+    - Match sequences matching account number formats.
+    - Apply checksum algorithms where applicable.
+
+Inputs/Outputs:
+    - Inputs: text string.
+    - Outputs: list of `EntitySpan` for account identifiers.
+
+Public contracts (planned):
+    - `detect(text)`: Return spans for account numbers.
+
+Notes/Edge cases:
+    - Should minimize false positives from random digit strings.
+
+Dependencies:
+    - `patterns` module and `checksum` utilities (optional).
+"""

--- a/src/redactor/detect/address_libpostal.py
+++ b/src/redactor/detect/address_libpostal.py
@@ -1,0 +1,22 @@
+"""Address detector using libpostal.
+
+Purpose:
+    Parse and identify mailing addresses in text.
+
+Key responsibilities:
+    - Leverage libpostal for normalization and parsing.
+    - Emit spans labeled as `ADDRESS` with structured components.
+
+Inputs/Outputs:
+    - Inputs: text string.
+    - Outputs: list of `EntitySpan` for addresses.
+
+Public contracts (planned):
+    - `detect(text)`: Return spans representing addresses.
+
+Notes/Edge cases:
+    - Requires libpostal data installation; handle absence gracefully.
+
+Dependencies:
+    - `libpostal` (optional, heavy).
+"""

--- a/src/redactor/detect/aliases.py
+++ b/src/redactor/detect/aliases.py
@@ -1,0 +1,22 @@
+"""Alias detector.
+
+Purpose:
+    Discover known aliases or AKA references for entities.
+
+Key responsibilities:
+    - Scan for patterns like "aka" or "alias" followed by a name.
+    - Normalize aliases for linking with primary identities.
+
+Inputs/Outputs:
+    - Inputs: text string.
+    - Outputs: list of `EntitySpan` for alias names.
+
+Public contracts (planned):
+    - `detect(text)`: Return spans for alias mentions.
+
+Notes/Edge cases:
+    - Multiple aliases in a single phrase should produce distinct spans.
+
+Dependencies:
+    - `patterns` module.
+"""

--- a/src/redactor/detect/bank_org.py
+++ b/src/redactor/detect/bank_org.py
@@ -1,0 +1,22 @@
+"""Bank organization detector.
+
+Purpose:
+    Recognize names of financial institutions.
+
+Key responsibilities:
+    - Use curated lists or NER models to identify bank names.
+    - Emit spans labeled as `BANK_ORG`.
+
+Inputs/Outputs:
+    - Inputs: text string.
+    - Outputs: list of `EntitySpan` for bank organizations.
+
+Public contracts (planned):
+    - `detect(text)`: Return spans for bank names.
+
+Notes/Edge cases:
+    - Ambiguous abbreviations require context-aware handling.
+
+Dependencies:
+    - Optional external datasets or NER libraries.
+"""

--- a/src/redactor/detect/base.py
+++ b/src/redactor/detect/base.py
@@ -1,0 +1,23 @@
+"""Detection base definitions.
+
+Purpose:
+    Outline common data structures and interfaces for all detectors.
+
+Key responsibilities:
+    - Define the `EntitySpan` dataclass capturing detected entity metadata.
+    - Specify the `Detector` protocol for pluggable detectors.
+
+Inputs/Outputs:
+    - Inputs: text string and optional context information.
+    - Outputs: list of `EntitySpan` instances.
+
+Public contracts (planned):
+    - `EntitySpan`: (start, end, text, label, source, confidence, attrs, entity_id).
+    - `Detector.detect(text, context=None)`: Return list of `EntitySpan`.
+
+Notes/Edge cases:
+    - Offsets must refer to the original text prior to normalization.
+
+Dependencies:
+    - `dataclasses` from standard library.
+"""

--- a/src/redactor/detect/date_dob.py
+++ b/src/redactor/detect/date_dob.py
@@ -1,0 +1,22 @@
+"""Date-of-birth detector.
+
+Purpose:
+    Identify dates that likely correspond to a person's birthdate.
+
+Key responsibilities:
+    - Use contextual cues around generic dates to infer DOB.
+    - Emit spans labeled as `DATE_DOB`.
+
+Inputs/Outputs:
+    - Inputs: text string.
+    - Outputs: list of `EntitySpan` for DOB mentions.
+
+Public contracts (planned):
+    - `detect(text)`: Return spans for probable birth dates.
+
+Notes/Edge cases:
+    - Age references ("born on") improve precision.
+
+Dependencies:
+    - Relies on `date_generic` detector output.
+"""

--- a/src/redactor/detect/date_generic.py
+++ b/src/redactor/detect/date_generic.py
@@ -1,0 +1,22 @@
+"""Generic date detector.
+
+Purpose:
+    Find date expressions in various formats.
+
+Key responsibilities:
+    - Match numeric and textual date representations.
+    - Normalize to a standard format for comparison.
+
+Inputs/Outputs:
+    - Inputs: text string.
+    - Outputs: list of `EntitySpan` for date occurrences.
+
+Public contracts (planned):
+    - `detect(text)`: Return spans for dates.
+
+Notes/Edge cases:
+    - Ambiguous formats (e.g., 01/02/03) require locale awareness.
+
+Dependencies:
+    - `dateutil` (optional).
+"""

--- a/src/redactor/detect/email.py
+++ b/src/redactor/detect/email.py
@@ -1,0 +1,22 @@
+"""Email address detector.
+
+Purpose:
+    Identify email addresses in text using pattern matching.
+
+Key responsibilities:
+    - Apply regex patterns for various email formats.
+    - Emit `EntitySpan` objects labeled as emails.
+
+Inputs/Outputs:
+    - Inputs: text string.
+    - Outputs: list of `EntitySpan` representing emails.
+
+Public contracts (planned):
+    - `detect(text)`: Return spans for email addresses.
+
+Notes/Edge cases:
+    - Should ignore false positives in code blocks or URLs.
+
+Dependencies:
+    - `patterns` module for regexes.
+"""

--- a/src/redactor/detect/names_person.py
+++ b/src/redactor/detect/names_person.py
@@ -1,0 +1,22 @@
+"""Personal name detector.
+
+Purpose:
+    Identify person names using heuristics or NER.
+
+Key responsibilities:
+    - Combine pattern matching with NLP models.
+    - Output spans labeled as `PERSON`.
+
+Inputs/Outputs:
+    - Inputs: text string.
+    - Outputs: list of `EntitySpan` for names.
+
+Public contracts (planned):
+    - `detect(text)`: Return spans for person names.
+
+Notes/Edge cases:
+    - Must handle honorifics and initials gracefully.
+
+Dependencies:
+    - `spacy` or similar (optional).
+"""

--- a/src/redactor/detect/ner_spacy.py
+++ b/src/redactor/detect/ner_spacy.py
@@ -1,0 +1,22 @@
+"""spaCy-based NER detector.
+
+Purpose:
+    Use spaCy's statistical models to find entities not covered by rules.
+
+Key responsibilities:
+    - Load spaCy language models lazily.
+    - Convert model entities to `EntitySpan` objects.
+
+Inputs/Outputs:
+    - Inputs: text string.
+    - Outputs: list of `EntitySpan` from spaCy entities.
+
+Public contracts (planned):
+    - `detect(text)`: Run spaCy NER on text.
+
+Notes/Edge cases:
+    - Heavy dependency; module should fail gracefully if spaCy is missing.
+
+Dependencies:
+    - `spacy` (optional, heavy).
+"""

--- a/src/redactor/detect/patterns.py
+++ b/src/redactor/detect/patterns.py
@@ -1,0 +1,23 @@
+"""Common regular expression patterns for detectors.
+
+Purpose:
+    Provide reusable regex expressions for identifying sensitive entities.
+
+Key responsibilities:
+    - Store compiled patterns for emails, phones, etc.
+    - Expose helpers to apply patterns consistently.
+
+Inputs/Outputs:
+    - Inputs: text string to search.
+    - Outputs: iterator of match objects or spans.
+
+Public contracts (planned):
+    - `get_pattern(name)`: Retrieve compiled regex by key.
+    - `iter_matches(name, text)`: Yield spans for a pattern.
+
+Notes/Edge cases:
+    - Patterns must balance recall and precision.
+
+Dependencies:
+    - `re` module.
+"""

--- a/src/redactor/detect/phone.py
+++ b/src/redactor/detect/phone.py
@@ -1,0 +1,22 @@
+"""Phone number detector.
+
+Purpose:
+    Locate telephone numbers in free-form text.
+
+Key responsibilities:
+    - Use regex patterns for international formats.
+    - Normalize captured numbers for comparison.
+
+Inputs/Outputs:
+    - Inputs: text string.
+    - Outputs: list of `EntitySpan` representing phone numbers.
+
+Public contracts (planned):
+    - `detect(text)`: Return spans for phone numbers.
+
+Notes/Edge cases:
+    - Extension numbers and short codes require special handling.
+
+Dependencies:
+    - `patterns` module for regexes.
+"""

--- a/src/redactor/evaluation/__init__.py
+++ b/src/redactor/evaluation/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation helpers and benchmark utilities."""

--- a/src/redactor/evaluation/fuzz.py
+++ b/src/redactor/evaluation/fuzz.py
@@ -1,0 +1,22 @@
+"""Fuzz testing utilities.
+
+Purpose:
+    Generate synthetic documents to stress-test the redaction pipeline.
+
+Key responsibilities:
+    - Create random but realistic text with embedded entities.
+    - Exercise detectors under diverse conditions.
+
+Inputs/Outputs:
+    - Inputs: random seed and generation parameters.
+    - Outputs: synthetic text documents.
+
+Public contracts (planned):
+    - `generate(seed, params)`: Produce test document string.
+
+Notes/Edge cases:
+    - Generated data should not resemble real individuals.
+
+Dependencies:
+    - `faker` library (optional).
+"""

--- a/src/redactor/evaluation/metrics.py
+++ b/src/redactor/evaluation/metrics.py
@@ -1,0 +1,23 @@
+"""Evaluation metrics.
+
+Purpose:
+    Define metrics for measuring redaction performance.
+
+Key responsibilities:
+    - Compute precision, recall, and related statistics.
+    - Provide utilities for comparing detector outputs to ground truth.
+
+Inputs/Outputs:
+    - Inputs: lists of predicted and true `EntitySpan` objects.
+    - Outputs: metric scores as floats.
+
+Public contracts (planned):
+    - `precision(references, predictions)`: Compute precision.
+    - `recall(references, predictions)`: Compute recall.
+
+Notes/Edge cases:
+    - Handling partial overlaps between spans requires special logic.
+
+Dependencies:
+    - `detect.base` for `EntitySpan` definitions.
+"""

--- a/src/redactor/io/__init__.py
+++ b/src/redactor/io/__init__.py
@@ -1,0 +1,1 @@
+"""I/O subpackage with file readers and writers for various formats."""

--- a/src/redactor/io/readers/__init__.py
+++ b/src/redactor/io/readers/__init__.py
@@ -1,0 +1,1 @@
+"""Reader implementations for ingesting text from different file types."""

--- a/src/redactor/io/readers/docx_reader.py
+++ b/src/redactor/io/readers/docx_reader.py
@@ -1,0 +1,22 @@
+"""DOCX document reader.
+
+Purpose:
+    Extract text from Microsoft Word documents.
+
+Key responsibilities:
+    - Parse DOCX files and concatenate paragraph text.
+    - Preserve basic structural markers when possible.
+
+Inputs/Outputs:
+    - Inputs: path to a .docx file.
+    - Outputs: extracted text string.
+
+Public contracts (planned):
+    - `read_docx(path)`: Return text content from a DOCX file.
+
+Notes/Edge cases:
+    - Embedded images and tables are ignored.
+
+Dependencies:
+    - `python-docx` (optional).
+"""

--- a/src/redactor/io/readers/html_reader.py
+++ b/src/redactor/io/readers/html_reader.py
@@ -1,0 +1,22 @@
+"""HTML document reader.
+
+Purpose:
+    Extract visible text from HTML pages.
+
+Key responsibilities:
+    - Strip HTML tags and scripts.
+    - Decode entities and normalize whitespace.
+
+Inputs/Outputs:
+    - Inputs: HTML string or file path.
+    - Outputs: cleaned text string.
+
+Public contracts (planned):
+    - `read_html(source)`: Return visible text from HTML.
+
+Notes/Edge cases:
+    - Must avoid executing embedded JavaScript.
+
+Dependencies:
+    - `beautifulsoup4` (optional).
+"""

--- a/src/redactor/io/readers/pdf_reader.py
+++ b/src/redactor/io/readers/pdf_reader.py
@@ -1,0 +1,22 @@
+"""PDF document reader.
+
+Purpose:
+    Extract text from PDF files using lightweight parsing.
+
+Key responsibilities:
+    - Convert PDF pages to text strings.
+    - Maintain page boundaries for downstream processing.
+
+Inputs/Outputs:
+    - Inputs: path to a PDF file.
+    - Outputs: list of page texts or combined string.
+
+Public contracts (planned):
+    - `read_pdf(path)`: Yield text content from each page.
+
+Notes/Edge cases:
+    - Scanned PDFs may require OCR (not included).
+
+Dependencies:
+    - `pdfplumber` or similar (optional).
+"""

--- a/src/redactor/io/readers/txt_reader.py
+++ b/src/redactor/io/readers/txt_reader.py
@@ -1,0 +1,22 @@
+"""Plain text reader.
+
+Purpose:
+    Load UTF-8 encoded text files into memory.
+
+Key responsibilities:
+    - Open text files and return their contents as strings.
+    - Handle newline normalization where needed.
+
+Inputs/Outputs:
+    - Inputs: file path or file-like object.
+    - Outputs: raw text string.
+
+Public contracts (planned):
+    - `read_text(path)`: Return file contents as text.
+
+Notes/Edge cases:
+    - Large files may require streaming support.
+
+Dependencies:
+    - `pathlib`.
+"""

--- a/src/redactor/io/writers/__init__.py
+++ b/src/redactor/io/writers/__init__.py
@@ -1,0 +1,1 @@
+"""Writer implementations for exporting redacted text to different formats."""

--- a/src/redactor/io/writers/docx_writer.py
+++ b/src/redactor/io/writers/docx_writer.py
@@ -1,0 +1,22 @@
+"""DOCX document writer.
+
+Purpose:
+    Save redacted output as a DOCX document.
+
+Key responsibilities:
+    - Create basic DOCX structure and insert text.
+    - Preserve minimal formatting if provided.
+
+Inputs/Outputs:
+    - Inputs: text string, output path.
+    - Outputs: DOCX file on disk.
+
+Public contracts (planned):
+    - `write_docx(text, path)`: Generate a DOCX document from text.
+
+Notes/Edge cases:
+    - Complex styling and embedded media are not supported.
+
+Dependencies:
+    - `python-docx` (optional).
+"""

--- a/src/redactor/io/writers/html_writer.py
+++ b/src/redactor/io/writers/html_writer.py
@@ -1,0 +1,22 @@
+"""HTML document writer.
+
+Purpose:
+    Serialize redacted text into a minimal HTML page.
+
+Key responsibilities:
+    - Wrap text in basic HTML structure.
+    - Escape special characters appropriately.
+
+Inputs/Outputs:
+    - Inputs: text string, output path.
+    - Outputs: HTML file on disk.
+
+Public contracts (planned):
+    - `write_html(text, path)`: Save text within an HTML template.
+
+Notes/Edge cases:
+    - CSS and JavaScript are intentionally omitted.
+
+Dependencies:
+    - standard library only.
+"""

--- a/src/redactor/io/writers/pdf_writer.py
+++ b/src/redactor/io/writers/pdf_writer.py
@@ -1,0 +1,22 @@
+"""PDF document writer.
+
+Purpose:
+    Export redacted text into a simple PDF file.
+
+Key responsibilities:
+    - Render text onto PDF pages.
+    - Support basic pagination.
+
+Inputs/Outputs:
+    - Inputs: text string, output path.
+    - Outputs: PDF file on disk.
+
+Public contracts (planned):
+    - `write_pdf(text, path)`: Create a PDF document from text.
+
+Notes/Edge cases:
+    - Complex layout and fonts are out of scope.
+
+Dependencies:
+    - `reportlab` or similar (optional).
+"""

--- a/src/redactor/io/writers/txt_writer.py
+++ b/src/redactor/io/writers/txt_writer.py
@@ -1,0 +1,22 @@
+"""Plain text writer.
+
+Purpose:
+    Output redacted text to UTF-8 encoded files.
+
+Key responsibilities:
+    - Write text to disk.
+    - Ensure newline and encoding consistency.
+
+Inputs/Outputs:
+    - Inputs: text string, output path.
+    - Outputs: created file on disk.
+
+Public contracts (planned):
+    - `write_text(text, path)`: Persist text to file.
+
+Notes/Edge cases:
+    - Existing files may need overwrite confirmation.
+
+Dependencies:
+    - `pathlib`.
+"""

--- a/src/redactor/link/__init__.py
+++ b/src/redactor/link/__init__.py
@@ -1,0 +1,1 @@
+"""Entity linking components for merging and resolving spans."""

--- a/src/redactor/link/alias_resolver.py
+++ b/src/redactor/link/alias_resolver.py
@@ -1,0 +1,22 @@
+"""Alias resolution utilities.
+
+Purpose:
+    Connect detected aliases to their primary entities.
+
+Key responsibilities:
+    - Maintain mapping of alias spans to canonical entity identifiers.
+    - Provide lookup functions for downstream pseudonymization.
+
+Inputs/Outputs:
+    - Inputs: list of `EntitySpan` objects with alias labels.
+    - Outputs: updated spans with `entity_id` filled based on alias matches.
+
+Public contracts (planned):
+    - `resolve_aliases(spans)`: Assign `entity_id` for alias spans.
+
+Notes/Edge cases:
+    - Different entities may share identical aliases; context is needed.
+
+Dependencies:
+    - Standard library only.
+"""

--- a/src/redactor/link/coref.py
+++ b/src/redactor/link/coref.py
@@ -1,0 +1,22 @@
+"""Coreference resolution utilities.
+
+Purpose:
+    Link pronouns and repeated mentions to primary entities.
+
+Key responsibilities:
+    - Group spans referring to the same entity across the document.
+    - Provide mappings from aliases or pronouns to canonical IDs.
+
+Inputs/Outputs:
+    - Inputs: list of `EntitySpan` objects.
+    - Outputs: updated spans with `entity_id` fields populated.
+
+Public contracts (planned):
+    - `resolve(spans, text)`: Annotate spans with coreference information.
+
+Notes/Edge cases:
+    - Requires context windowing to avoid cross-document leaks.
+
+Dependencies:
+    - NLP coreference libraries (optional).
+"""

--- a/src/redactor/link/entity_clusterer.py
+++ b/src/redactor/link/entity_clusterer.py
@@ -1,0 +1,22 @@
+"""Entity clustering utilities.
+
+Purpose:
+    Group related spans into clusters representing the same real-world entity.
+
+Key responsibilities:
+    - Apply heuristic or probabilistic clustering.
+    - Output cluster identifiers for sets of spans.
+
+Inputs/Outputs:
+    - Inputs: list of `EntitySpan` objects.
+    - Outputs: mapping of cluster ID to member span IDs.
+
+Public contracts (planned):
+    - `cluster(spans)`: Return cluster assignments for spans.
+
+Notes/Edge cases:
+    - Clustering should be deterministic given the same inputs.
+
+Dependencies:
+    - `networkx` or similar graph libraries (optional).
+"""

--- a/src/redactor/link/span_merger.py
+++ b/src/redactor/link/span_merger.py
@@ -1,0 +1,22 @@
+"""Span merging utilities.
+
+Purpose:
+    Combine overlapping or adjacent entity spans into coherent results.
+
+Key responsibilities:
+    - Resolve conflicts using label precedence rules.
+    - Prefer longest spans when overlaps occur.
+
+Inputs/Outputs:
+    - Inputs: iterable of `EntitySpan` objects.
+    - Outputs: list of merged `EntitySpan` objects.
+
+Public contracts (planned):
+    - `merge(spans)`: Return merged spans applying precedence strategy.
+
+Notes/Edge cases:
+    - Nested spans from different detectors require deterministic ordering.
+
+Dependencies:
+    - `detect.base` for `EntitySpan` definition.
+"""

--- a/src/redactor/preprocess/__init__.py
+++ b/src/redactor/preprocess/__init__.py
@@ -1,0 +1,1 @@
+"""Text preprocessing steps for normalization and segmentation."""

--- a/src/redactor/preprocess/layout_reconstructor.py
+++ b/src/redactor/preprocess/layout_reconstructor.py
@@ -1,0 +1,22 @@
+"""Layout reconstruction utilities.
+
+Purpose:
+    Rebuild document structure from segmented text to support block-level redaction.
+
+Key responsibilities:
+    - Group related lines into blocks such as addresses or party sections.
+    - Track original character offsets for precise replacement.
+
+Inputs/Outputs:
+    - Inputs: sequence of text segments with offsets.
+    - Outputs: structured blocks with span information.
+
+Public contracts (planned):
+    - `reconstruct(segments)`: Yield blocks representing logical layout units.
+
+Notes/Edge cases:
+    - Full-block replacement is used to prevent partial leakage of sensitive data.
+
+Dependencies:
+    - Standard library only.
+"""

--- a/src/redactor/preprocess/normalizer.py
+++ b/src/redactor/preprocess/normalizer.py
@@ -1,0 +1,22 @@
+"""Text normalization utilities.
+
+Purpose:
+    Standardize input text before detection.
+
+Key responsibilities:
+    - Normalize whitespace and Unicode characters.
+    - Apply configurable lowercasing or transliteration.
+
+Inputs/Outputs:
+    - Inputs: raw text string.
+    - Outputs: normalized text string.
+
+Public contracts (planned):
+    - `normalize(text, config)`: Return normalized text according to settings.
+
+Notes/Edge cases:
+    - Should preserve original offsets when possible.
+
+Dependencies:
+    - `unicodedata`.
+"""

--- a/src/redactor/preprocess/segmenter.py
+++ b/src/redactor/preprocess/segmenter.py
@@ -1,0 +1,22 @@
+"""Text segmentation utilities.
+
+Purpose:
+    Split normalized text into logical units such as sentences or paragraphs.
+
+Key responsibilities:
+    - Provide sentence and paragraph tokenization.
+    - Preserve offset mappings for each segment.
+
+Inputs/Outputs:
+    - Inputs: normalized text string.
+    - Outputs: list of segments with offsets.
+
+Public contracts (planned):
+    - `segment(text)`: Return iterable of segments.
+
+Notes/Edge cases:
+    - Multilingual segmentation may require external libraries.
+
+Dependencies:
+    - `regex` or `nltk` (optional).
+"""

--- a/src/redactor/pseudo/__init__.py
+++ b/src/redactor/pseudo/__init__.py
@@ -1,0 +1,1 @@
+"""Pseudonymization utilities for generating surrogate data."""

--- a/src/redactor/pseudo/address_rules.py
+++ b/src/redactor/pseudo/address_rules.py
@@ -1,0 +1,22 @@
+"""Address pseudonymization rules.
+
+Purpose:
+    Specify how detected addresses are replaced with synthetic alternatives.
+
+Key responsibilities:
+    - Generate plausible but nonexistent addresses.
+    - Maintain structural components like street, city, and postal code.
+
+Inputs/Outputs:
+    - Inputs: parsed address components and seed.
+    - Outputs: formatted pseudonymous address string.
+
+Public contracts (planned):
+    - `apply(address_parts, seed)`: Return pseudonymized address.
+
+Notes/Edge cases:
+    - Must avoid generating real residential locations.
+
+Dependencies:
+    - `generator` module.
+"""

--- a/src/redactor/pseudo/case_preserver.py
+++ b/src/redactor/pseudo/case_preserver.py
@@ -1,0 +1,22 @@
+"""Case preservation helpers.
+
+Purpose:
+    Maintain original casing patterns when substituting pseudonyms.
+
+Key responsibilities:
+    - Analyze casing of source tokens.
+    - Apply similar casing to generated pseudonyms.
+
+Inputs/Outputs:
+    - Inputs: original text, pseudonym.
+    - Outputs: pseudonym adjusted for case.
+
+Public contracts (planned):
+    - `preserve_case(source, replacement)`: Return case-adjusted replacement.
+
+Notes/Edge cases:
+    - Mixed-case tokens require per-character analysis.
+
+Dependencies:
+    - Standard library only.
+"""

--- a/src/redactor/pseudo/generator.py
+++ b/src/redactor/pseudo/generator.py
@@ -1,0 +1,22 @@
+"""Pseudonym generator.
+
+Purpose:
+    Produce consistent surrogate values for detected entities.
+
+Key responsibilities:
+    - Use seeded random sources to generate pseudonyms.
+    - Support multiple entity types (names, addresses, numbers).
+
+Inputs/Outputs:
+    - Inputs: entity label, original text, seed.
+    - Outputs: pseudonym string.
+
+Public contracts (planned):
+    - `generate(label, text, seed)`: Return pseudonym for entity.
+
+Notes/Edge cases:
+    - Generated values must avoid real-world collisions.
+
+Dependencies:
+    - `seed` module.
+"""

--- a/src/redactor/pseudo/name_rules.py
+++ b/src/redactor/pseudo/name_rules.py
@@ -1,0 +1,22 @@
+"""Name pseudonymization rules.
+
+Purpose:
+    Define how personal names should be transformed into pseudonyms.
+
+Key responsibilities:
+    - Preserve formatting such as capitalization and initials.
+    - Support deterministic mapping for repeated names.
+
+Inputs/Outputs:
+    - Inputs: original name string and seed.
+    - Outputs: pseudonymized name string.
+
+Public contracts (planned):
+    - `apply(name, seed)`: Return pseudonym for a name.
+
+Notes/Edge cases:
+    - Must handle multi-part names and honorifics.
+
+Dependencies:
+    - `generator` module.
+"""

--- a/src/redactor/pseudo/number_rules.py
+++ b/src/redactor/pseudo/number_rules.py
@@ -1,0 +1,22 @@
+"""Number pseudonymization rules.
+
+Purpose:
+    Transform numeric identifiers such as account or phone numbers.
+
+Key responsibilities:
+    - Preserve length and formatting (dashes, spaces).
+    - Ensure generated numbers are not valid identifiers.
+
+Inputs/Outputs:
+    - Inputs: original number string and seed.
+    - Outputs: pseudonymized number string.
+
+Public contracts (planned):
+    - `apply(number, seed)`: Return pseudonymous number.
+
+Notes/Edge cases:
+    - Checksum digits may need recalculation or removal.
+
+Dependencies:
+    - `generator` module.
+"""

--- a/src/redactor/pseudo/seed.py
+++ b/src/redactor/pseudo/seed.py
@@ -1,0 +1,22 @@
+"""Pseudorandom seed management.
+
+Purpose:
+    Provide deterministic seeding for pseudonym generation.
+
+Key responsibilities:
+    - Derive seeds using HMAC with a secret key.
+    - Ensure reproducibility across runs without exposing the secret.
+
+Inputs/Outputs:
+    - Inputs: secret from environment, optional user identifier.
+    - Outputs: integer seed values for random generators.
+
+Public contracts (planned):
+    - `derive_seed(key_material)`: Return deterministic seed.
+
+Notes/Edge cases:
+    - Secret key must never be persisted; environment only.
+
+Dependencies:
+    - `hashlib` and `hmac` from standard library.
+"""

--- a/src/redactor/replace/__init__.py
+++ b/src/redactor/replace/__init__.py
@@ -1,0 +1,1 @@
+"""Replacement planning and application components."""

--- a/src/redactor/replace/applier.py
+++ b/src/redactor/replace/applier.py
@@ -1,0 +1,22 @@
+"""Replacement plan applier.
+
+Purpose:
+    Execute a replacement plan to produce redacted text.
+
+Key responsibilities:
+    - Apply replacements in a stable order.
+    - Optionally preserve unmatched text segments.
+
+Inputs/Outputs:
+    - Inputs: original text and replacement plan.
+    - Outputs: redacted text string.
+
+Public contracts (planned):
+    - `apply_plan(text, plan)`: Return redacted text.
+
+Notes/Edge cases:
+    - Must handle overlapping or nested replacements safely.
+
+Dependencies:
+    - Standard library only.
+"""

--- a/src/redactor/replace/plan_builder.py
+++ b/src/redactor/replace/plan_builder.py
@@ -1,0 +1,22 @@
+"""Replacement plan builder.
+
+Purpose:
+    Construct a set of operations to replace detected spans.
+
+Key responsibilities:
+    - Combine spans and pseudonyms into an ordered plan.
+    - Ensure offsets remain valid after sequential replacements.
+
+Inputs/Outputs:
+    - Inputs: original text, list of spans, pseudonym generator.
+    - Outputs: replacement plan data structure.
+
+Public contracts (planned):
+    - `build_plan(text, spans, pseudo)`: Create plan for text replacement.
+
+Notes/Edge cases:
+    - Overlapping spans must be resolved before plan creation.
+
+Dependencies:
+    - `link` and `pseudo` modules.
+"""

--- a/src/redactor/utils/__init__.py
+++ b/src/redactor/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Miscellaneous utility functions used across the redactor package."""

--- a/src/redactor/utils/errors.py
+++ b/src/redactor/utils/errors.py
@@ -1,0 +1,23 @@
+"""Custom exception types.
+
+Purpose:
+    Define project-specific error classes for clarity.
+
+Key responsibilities:
+    - Provide base exception for package errors.
+    - Distinguish user vs system errors.
+
+Inputs/Outputs:
+    - Inputs: error message.
+    - Outputs: exception instances.
+
+Public contracts (planned):
+    - `RedactorError`: Base class for package exceptions.
+    - `ConfigurationError`: Raised for invalid configuration.
+
+Notes/Edge cases:
+    - Exceptions should include context to aid debugging.
+
+Dependencies:
+    - Standard library only.
+"""

--- a/src/redactor/utils/logging.py
+++ b/src/redactor/utils/logging.py
@@ -1,0 +1,22 @@
+"""Logging utilities.
+
+Purpose:
+    Centralize logging configuration for the package.
+
+Key responsibilities:
+    - Provide helper to obtain configured loggers.
+    - Allow optional verbose/debug modes.
+
+Inputs/Outputs:
+    - Inputs: module name and verbosity settings.
+    - Outputs: configured `logging.Logger` instances.
+
+Public contracts (planned):
+    - `get_logger(name)`: Return a logger configured for the package.
+
+Notes/Edge cases:
+    - Logging configuration should be idempotent.
+
+Dependencies:
+    - Python `logging` module.
+"""

--- a/src/redactor/utils/textspan.py
+++ b/src/redactor/utils/textspan.py
@@ -1,0 +1,22 @@
+"""Text span utilities.
+
+Purpose:
+    Provide helper functions for manipulating text spans and offsets.
+
+Key responsibilities:
+    - Convert between character and byte offsets.
+    - Adjust spans after text modifications.
+
+Inputs/Outputs:
+    - Inputs: span tuples or `EntitySpan` objects.
+    - Outputs: transformed spans or offset mappings.
+
+Public contracts (planned):
+    - `shift_spans(spans, index, delta)`: Adjust spans after insertion.
+
+Notes/Edge cases:
+    - Unicode code points vs byte offsets must be handled carefully.
+
+Dependencies:
+    - Standard library only.
+"""

--- a/src/redactor/verify/__init__.py
+++ b/src/redactor/verify/__init__.py
@@ -1,0 +1,1 @@
+"""Verification helpers ensuring redaction quality."""

--- a/src/redactor/verify/heuristics.py
+++ b/src/redactor/verify/heuristics.py
@@ -1,0 +1,22 @@
+"""Verification heuristics.
+
+Purpose:
+    Provide lightweight checks for common redaction mistakes.
+
+Key responsibilities:
+    - Search for placeholder patterns or obvious artifacts.
+    - Flag suspicious outputs for manual review.
+
+Inputs/Outputs:
+    - Inputs: redacted text.
+    - Outputs: list of heuristic warnings.
+
+Public contracts (planned):
+    - `run(text)`: Return list of heuristic messages.
+
+Notes/Edge cases:
+    - Heuristics should produce minimal false positives.
+
+Dependencies:
+    - Standard library only.
+"""

--- a/src/redactor/verify/report.py
+++ b/src/redactor/verify/report.py
@@ -1,0 +1,22 @@
+"""Verification report generation.
+
+Purpose:
+    Summarize verification results for downstream consumption.
+
+Key responsibilities:
+    - Aggregate scanner and heuristic findings.
+    - Output human-readable or machine-readable reports.
+
+Inputs/Outputs:
+    - Inputs: verification findings data.
+    - Outputs: structured report (dict or text).
+
+Public contracts (planned):
+    - `generate(findings)`: Return verification report.
+
+Notes/Edge cases:
+    - Report format should be extensible.
+
+Dependencies:
+    - Standard library only.
+"""

--- a/src/redactor/verify/scanner.py
+++ b/src/redactor/verify/scanner.py
@@ -1,0 +1,22 @@
+"""Residual sensitive data scanner.
+
+Purpose:
+    Re-scan redacted text for leftover sensitive information.
+
+Key responsibilities:
+    - Run detectors on redacted output to ensure completeness.
+    - Aggregate results for reporting.
+
+Inputs/Outputs:
+    - Inputs: redacted text.
+    - Outputs: list of detected spans or empty list.
+
+Public contracts (planned):
+    - `scan(text)`: Return residual spans after redaction.
+
+Notes/Edge cases:
+    - Must avoid infinite loops if scanners trigger replacements.
+
+Dependencies:
+    - `detect` package.
+"""

--- a/tests/test_package_layout.py
+++ b/tests/test_package_layout.py
@@ -1,0 +1,18 @@
+# Tests for verifying the package skeleton is importable and documented.
+
+import importlib
+import pkgutil
+
+import redactor
+
+
+def test_root_package_has_docstring() -> None:
+    """The root package should define a module docstring."""
+    assert redactor.__doc__ and redactor.__doc__.strip()
+
+
+def test_all_modules_have_docstrings() -> None:
+    """Ensure every submodule can be imported and has a docstring."""
+    for module_info in pkgutil.walk_packages(redactor.__path__, redactor.__name__ + "."):
+        module = importlib.import_module(module_info.name)
+        assert module.__doc__ and module.__doc__.strip(), f"Missing docstring in {module_info.name}"


### PR DESCRIPTION
## Summary
- scaffold redactor package modules with descriptive docstrings
- document architecture overview in README
- add test ensuring each module imports and exposes a docstring

## Testing
- `pip install -e . --no-build-isolation` *(fails: Cannot import 'setuptools.build_meta')*
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b32aab2ba08325a238c770c35b5ea2