### PR TITLE
feat(core): add EntitySpan, Detector protocol, and span utilities

### DIFF
--- a/src/redactor/detect/base.py
+++ b/src/redactor/detect/base.py
@@ -1,23 +1,104 @@
-"""Detection base definitions.
+"""Core detection model and protocol definitions.
 
-Purpose:
-    Outline common data structures and interfaces for all detectors.
-
-Key responsibilities:
-    - Define the `EntitySpan` dataclass capturing detected entity metadata.
-    - Specify the `Detector` protocol for pluggable detectors.
-
-Inputs/Outputs:
-    - Inputs: text string and optional context information.
-    - Outputs: list of `EntitySpan` instances.
-
-Public contracts (planned):
-    - `EntitySpan`: (start, end, text, label, source, confidence, attrs, entity_id).
-    - `Detector.detect(text, context=None)`: Return list of `EntitySpan`.
-
-Notes/Edge cases:
-    - Offsets must refer to the original text prior to normalization.
-
-Dependencies:
-    - `dataclasses` from standard library.
+This module defines the minimal strongly‑typed primitives shared by all
+detectors.  Spans follow the half‑open interval convention ``[start, end)``
+where ``start`` is inclusive and ``end`` is exclusive.  Detectors must ensure
+that returned spans fall within the bounds of the analysed text and do not
+contain duplicates.  Overlap resolution is deferred to later pipeline steps.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+from redactor.utils.errors import SpanOutOfBoundsError
+
+
+class EntityLabel(Enum):
+    """Enumeration of supported entity labels."""
+
+    PERSON = "PERSON"
+    ORG = "ORG"
+    BANK_ORG = "BANK_ORG"
+    EMAIL = "EMAIL"
+    PHONE = "PHONE"
+    ACCOUNT_ID = "ACCOUNT_ID"
+    ADDRESS_BLOCK = "ADDRESS_BLOCK"
+    DOB = "DOB"
+    DATE_GENERIC = "DATE_GENERIC"
+    ALIAS_LABEL = "ALIAS_LABEL"
+    GPE = "GPE"
+    LOC = "LOC"
+    OTHER = "OTHER"
+
+
+@dataclass(slots=True, frozen=True)
+class EntitySpan:
+    """Detected entity information.
+
+    Attributes follow the half‑open interval convention where ``start`` is
+    inclusive and ``end`` is exclusive.  ``confidence`` must be between ``0``
+    and ``1``.
+    """
+
+    start: int
+    end: int
+    text: str
+    label: EntityLabel
+    source: str
+    confidence: float
+    attrs: dict[str, object] = field(default_factory=dict)
+    entity_id: str | None = None
+    span_id: str | None = None
+
+    def __post_init__(self) -> None:  # noqa: D401 - simple validation
+        if self.end <= self.start or self.start < 0:
+            raise SpanOutOfBoundsError(f"invalid span [{self.start}, {self.end})")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be within [0.0, 1.0]")
+
+    @property
+    def length(self) -> int:
+        """Return span length in characters."""
+
+        return self.end - self.start
+
+
+@runtime_checkable
+class Detector(Protocol):
+    """Protocol for entity detectors.
+
+    A detector analyses input text and returns zero or more :class:`EntitySpan`
+    objects describing detected entities.
+    """
+
+    def name(self) -> str:
+        """Return a short, stable identifier for the detector."""
+
+        ...
+
+    def detect(self, text: str, context: "DetectionContext | None" = None) -> list[EntitySpan]:
+        """Detect entities in ``text``.
+
+        Parameters
+        ----------
+        text:
+            The original text to analyse.
+        context:
+            Optional :class:`DetectionContext` with metadata that may influence
+            detection.
+        """
+
+        ...
+
+
+@dataclass(slots=True, frozen=True)
+class DetectionContext:
+    """Optional context information supplied to detectors."""
+
+    doc_id: str | None = None
+    locale: str | None = None
+    line_starts: tuple[int, ...] | None = None
+    config: object | None = None

--- a/src/redactor/utils/errors.py
+++ b/src/redactor/utils/errors.py
@@ -1,23 +1,13 @@
-"""Custom exception types.
+"""Typed exceptions for span validation and manipulation."""
 
-Purpose:
-    Define project-specific error classes for clarity.
 
-Key responsibilities:
-    - Provide base exception for package errors.
-    - Distinguish user vs system errors.
+class SpanError(ValueError):
+    """Base class for span related errors."""
 
-Inputs/Outputs:
-    - Inputs: error message.
-    - Outputs: exception instances.
 
-Public contracts (planned):
-    - `RedactorError`: Base class for package exceptions.
-    - `ConfigurationError`: Raised for invalid configuration.
+class OverlapError(SpanError):
+    """Raised when two spans overlap."""
 
-Notes/Edge cases:
-    - Exceptions should include context to aid debugging.
 
-Dependencies:
-    - Standard library only.
-"""
+class SpanOutOfBoundsError(SpanError):
+    """Raised when span coordinates are invalid or out of bounds."""

--- a/src/redactor/utils/textspan.py
+++ b/src/redactor/utils/textspan.py
@@ -1,22 +1,93 @@
-"""Text span utilities.
+"""Utility functions for working with text spans.
 
-Purpose:
-    Provide helper functions for manipulating text spans and offsets.
-
-Key responsibilities:
-    - Convert between character and byte offsets.
-    - Adjust spans after text modifications.
-
-Inputs/Outputs:
-    - Inputs: span tuples or `EntitySpan` objects.
-    - Outputs: transformed spans or offset mappings.
-
-Public contracts (planned):
-    - `shift_spans(spans, index, delta)`: Adjust spans after insertion.
-
-Notes/Edge cases:
-    - Unicode code points vs byte offsets must be handled carefully.
-
-Dependencies:
-    - Standard library only.
+The helpers in this module are pure and framework agnostic.  Spans are
+represented as half‑open intervals ``[start, end)`` where ``start`` is inclusive
+and ``end`` is exclusive.  Boundary touching spans therefore do not overlap.
 """
+
+from __future__ import annotations
+
+from bisect import bisect_right
+from typing import Literal
+
+from redactor.detect.base import EntitySpan
+from redactor.utils.errors import OverlapError
+
+
+def build_line_starts(text: str) -> tuple[int, ...]:
+    """Return the starting character index for each line in ``text``."""
+
+    starts = [0]
+    for idx, char in enumerate(text):
+        if char == "\n":
+            starts.append(idx + 1)
+    return tuple(starts)
+
+
+def char_to_line_col(index: int, line_starts: tuple[int, ...]) -> tuple[int, int]:
+    """Convert a character index to ``(line, col)`` using ``line_starts``.
+
+    Line and column numbers are zero‑based.
+    """
+
+    if index < 0:
+        raise ValueError("index must be non‑negative")
+    line = bisect_right(line_starts, index) - 1
+    if line < 0:
+        line = 0
+    col = index - line_starts[line]
+    return line, col
+
+
+def spans_overlap(a: tuple[int, int], b: tuple[int, int]) -> bool:
+    """Return ``True`` if span ``a`` overlaps span ``b``."""
+
+    return not (a[1] <= b[0] or b[1] <= a[0])
+
+
+def span_contains(outer: tuple[int, int], inner: tuple[int, int]) -> bool:
+    """Return ``True`` if ``outer`` fully contains ``inner``.
+
+    A span is considered contained only if ``inner`` is not positioned entirely
+    at ``outer``'s end boundary.
+    """
+
+    return outer[0] <= inner[0] < outer[1] and inner[1] <= outer[1]
+
+
+def sort_spans_for_replacement(
+    spans: list[EntitySpan], *, reverse: bool = True
+) -> list[EntitySpan]:
+    """Return ``spans`` sorted for safe replacement.
+
+    By default spans are sorted in descending order by ``start`` and then by
+    length.  This ordering allows in‑place text replacement without affecting
+    subsequent span offsets.
+    """
+
+    return sorted(spans, key=lambda s: (s.start, s.length), reverse=reverse)
+
+
+def ensure_non_overlapping(spans: list[EntitySpan]) -> None:
+    """Ensure that ``spans`` do not overlap.
+
+    Raises :class:`OverlapError` if any pair of spans overlaps.
+    """
+
+    ordered = sorted(spans, key=lambda s: s.start)
+    for prev, cur in zip(ordered, ordered[1:], strict=False):
+        if spans_overlap((prev.start, prev.end), (cur.start, cur.end)):
+            msg = f"Spans overlap: {prev} and {cur}"
+            raise OverlapError(msg)
+
+
+def detect_text_case(s: str) -> Literal["UPPER", "LOWER", "TITLE", "MIXED"]:
+    """Detect the predominant case of ``s``."""
+
+    if s.isupper():
+        return "UPPER"
+    if s.islower():
+        return "LOWER"
+    if s.istitle():
+        return "TITLE"
+    return "MIXED"

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -1,0 +1,49 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from redactor.detect.base import EntityLabel, EntitySpan
+
+
+def test_entity_span_fields_and_length() -> None:
+    span = EntitySpan(
+        start=0,
+        end=4,
+        text="John",
+        label=EntityLabel.PERSON,
+        source="dummy",
+        confidence=0.9,
+    )
+    assert span.start == 0
+    assert span.end == 4
+    assert span.text == "John"
+    assert span.length == 4
+
+
+def test_entity_span_immutable() -> None:
+    span = EntitySpan(
+        start=0,
+        end=1,
+        text="J",
+        label=EntityLabel.PERSON,
+        source="dummy",
+        confidence=0.5,
+    )
+    with pytest.raises(FrozenInstanceError):
+        span.start = 1  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "start,end,confidence",
+    [(-1, 2, 0.5), (5, 5, 0.5), (0, 1, 1.5), (0, 1, -0.1)],
+)
+def test_entity_span_validation(start: int, end: int, confidence: float) -> None:
+    with pytest.raises(ValueError):
+        EntitySpan(
+            start=start,
+            end=end,
+            text="x",
+            label=EntityLabel.OTHER,
+            source="dummy",
+            confidence=confidence,
+        )

--- a/tests/test_detector_protocol.py
+++ b/tests/test_detector_protocol.py
@@ -1,0 +1,22 @@
+from typing import List
+
+from redactor.detect.base import DetectionContext, Detector, EntityLabel, EntitySpan
+
+
+class DummyDetector:
+    def name(self) -> str:  # pragma: no cover - trivial
+        return "dummy"
+
+    def detect(self, text: str, context: DetectionContext | None = None) -> List[EntitySpan]:
+        _ = context
+        return [
+            EntitySpan(0, len(text), text, EntityLabel.OTHER, "dummy", 1.0),
+        ]
+
+
+def test_dummy_detector_runtime_checkable() -> None:
+    dummy = DummyDetector()
+    assert isinstance(dummy, Detector)
+    spans = dummy.detect("test")
+    assert isinstance(spans, list)
+    assert spans and isinstance(spans[0], EntitySpan)

--- a/tests/test_textspan_utils.py
+++ b/tests/test_textspan_utils.py
@@ -1,0 +1,61 @@
+import pytest
+
+from redactor.detect.base import EntityLabel, EntitySpan
+from redactor.utils.errors import OverlapError
+from redactor.utils.textspan import (
+    build_line_starts,
+    char_to_line_col,
+    detect_text_case,
+    ensure_non_overlapping,
+    sort_spans_for_replacement,
+    span_contains,
+    spans_overlap,
+)
+
+
+def test_line_starts_and_char_to_line_col() -> None:
+    text = "John\nDoe\n\n"
+    line_starts = build_line_starts(text)
+    assert line_starts == (0, 5, 9, 10)
+    assert char_to_line_col(0, line_starts) == (0, 0)
+    assert char_to_line_col(5, line_starts) == (1, 0)
+    assert char_to_line_col(9, line_starts) == (2, 0)
+
+
+def test_spans_overlap_truth_table() -> None:
+    assert spans_overlap((0, 2), (1, 3)) is True
+    assert spans_overlap((0, 2), (2, 4)) is False
+    assert spans_overlap((2, 4), (0, 2)) is False
+
+
+def test_span_contains() -> None:
+    assert span_contains((0, 5), (1, 3)) is True
+    assert span_contains((0, 5), (0, 5)) is True
+    assert span_contains((0, 5), (5, 5)) is False
+
+
+def test_sort_spans_for_replacement_ordering() -> None:
+    spans = [
+        EntitySpan(0, 3, "abc", EntityLabel.OTHER, "s", 1.0),
+        EntitySpan(5, 7, "de", EntityLabel.OTHER, "s", 1.0),
+        EntitySpan(5, 8, "def", EntityLabel.OTHER, "s", 1.0),
+    ]
+    ordered = sort_spans_for_replacement(spans)
+    assert [s.start for s in ordered] == [5, 5, 0]
+    assert [s.length for s in ordered] == [3, 2, 3]
+
+
+def test_ensure_non_overlapping() -> None:
+    spans = [
+        EntitySpan(0, 3, "abc", EntityLabel.OTHER, "s", 1.0),
+        EntitySpan(2, 5, "cde", EntityLabel.OTHER, "s", 1.0),
+    ]
+    with pytest.raises(OverlapError):
+        ensure_non_overlapping(spans)
+
+
+def test_detect_text_case() -> None:
+    assert detect_text_case("JOHN DOE") == "UPPER"
+    assert detect_text_case("john doe") == "LOWER"
+    assert detect_text_case("John Doe") == "TITLE"
+    assert detect_text_case("JoHn") == "MIXED"


### PR DESCRIPTION
## Summary
- introduce `EntityLabel` enum and immutable `EntitySpan` dataclass with validation
- add runtime-checkable `Detector` protocol and `DetectionContext`
- implement span utilities for line mapping, overlap checks and case detection
- provide typed span-related exceptions and comprehensive unit tests

## Testing
- `black --check src/redactor/utils/textspan.py src/redactor/detect/base.py src/redactor/utils/errors.py tests/test_core_models.py tests/test_textspan_utils.py tests/test_detector_protocol.py`
- `ruff check .`
- `mypy src/redactor/detect/base.py src/redactor/utils/textspan.py src/redactor/utils/errors.py tests/test_core_models.py tests/test_textspan_utils.py tests/test_detector_protocol.py`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32d7c557c83258100f4fdca067bf9