### PR TITLE
feat(io): add text readers/writers and extension-based IO registry

### DIFF
--- a/src/redactor/config/schema.py
+++ b/src/redactor/config/schema.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from pathlib import Path
 import os
+from collections.abc import Mapping
+from importlib import resources as importlib_resources
+from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from importlib import resources as importlib_resources
-from pydantic import BaseModel, ConfigDict, SecretStr, conint, confloat
-
+from pydantic import BaseModel, ConfigDict, SecretStr, confloat, conint
 
 # ---------------------------------------------------------------------------
 # Pydantic models

--- a/src/redactor/io/__init__.py
+++ b/src/redactor/io/__init__.py
@@ -1,1 +1,119 @@
-"""I/O subpackage with file readers and writers for various formats."""
+"""Extension based registry for file I/O.
+
+Only a minimal ``.txt`` reader/writer pair is registered by default.  The
+registry dispatches based on the file extension and performs no content
+normalization.  Newline characters and BOMs are handled by the underlying
+readers and writers.
+
+``UnsupportedFormatError`` is raised when attempting to read or write a file
+whose extension has no registered handler.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Callable
+
+from ..utils.errors import UnsupportedFormatError
+from .readers.txt_reader import read_text
+from .writers.txt_writer import write_text
+
+ReaderFunc = Callable[[str | os.PathLike[str]], str]
+WriterFunc = Callable[[str | os.PathLike[str], str], None]
+
+_READERS: dict[str, Callable[..., str]] = {}
+_WRITERS: dict[str, Callable[..., None]] = {}
+
+
+def register_reader(ext: str, func: Callable[..., str]) -> None:
+    """Register a reader for files ending with ``ext``.
+
+    Parameters
+    ----------
+    ext:
+        File extension including the dot (e.g. ``".txt"``).  Matching is
+        case-insensitive.
+    func:
+        Callable that reads a file and returns a string.
+    """
+
+    _READERS[ext.lower()] = func
+
+
+def register_writer(ext: str, func: Callable[..., None]) -> None:
+    """Register a writer for files ending with ``ext``."""
+
+    _WRITERS[ext.lower()] = func
+
+
+def get_extension(path: str | os.PathLike[str]) -> str:
+    """Return the lower-cased file extension of ``path`` (including the dot).
+
+    Returns an empty string when the path has no extension.
+    """
+
+    suffix = Path(path).suffix
+    return suffix.lower() if suffix else ""
+
+
+def read_file(path: str | os.PathLike[str], **kwargs: Any) -> str:
+    """Read ``path`` using the registered reader for its extension.
+
+    Parameters
+    ----------
+    path:
+        Path to the file being read.
+    **kwargs:
+        Additional keyword arguments forwarded to the underlying reader.
+
+    Raises
+    ------
+    UnsupportedFormatError
+        If no reader is registered for the file extension.
+    """
+
+    ext = get_extension(path)
+    reader = _READERS.get(ext)
+    if reader is None:
+        raise UnsupportedFormatError(f"Unsupported file extension: '{ext}'") from None
+    return reader(path, **kwargs)
+
+
+def write_file(path: str | os.PathLike[str], text: str, **kwargs: Any) -> None:
+    """Write ``text`` to ``path`` using the registered writer for its extension.
+
+    Parameters
+    ----------
+    path:
+        Destination file path.
+    text:
+        String content to be written.
+    **kwargs:
+        Additional keyword arguments forwarded to the underlying writer.
+
+    Raises
+    ------
+    UnsupportedFormatError
+        If no writer is registered for the file extension.
+    """
+
+    ext = get_extension(path)
+    writer = _WRITERS.get(ext)
+    if writer is None:
+        raise UnsupportedFormatError(f"Unsupported file extension: '{ext}'") from None
+    writer(path, text, **kwargs)
+
+
+register_reader(".txt", read_text)
+register_writer(".txt", write_text)
+
+__all__ = [
+    "ReaderFunc",
+    "WriterFunc",
+    "register_reader",
+    "register_writer",
+    "get_extension",
+    "read_file",
+    "write_file",
+]

--- a/src/redactor/io/readers/txt_reader.py
+++ b/src/redactor/io/readers/txt_reader.py
@@ -1,22 +1,56 @@
-"""Plain text reader.
+"""Plain-text reader.
 
-Purpose:
-    Load UTF-8 encoded text files into memory.
+This module exposes :func:`read_text` which loads text files without performing
+any content normalization.  Newline characters are preserved exactly as stored
+on disk and UTF-8 byte-order marks (BOM) are handled transparently by using the
+``"utf-8-sig"`` codec by default.
 
-Key responsibilities:
-    - Open text files and return their contents as strings.
-    - Handle newline normalization where needed.
-
-Inputs/Outputs:
-    - Inputs: file path or file-like object.
-    - Outputs: raw text string.
-
-Public contracts (planned):
-    - `read_text(path)`: Return file contents as text.
-
-Notes/Edge cases:
-    - Large files may require streaming support.
-
-Dependencies:
-    - `pathlib`.
+Example
+-------
+``read_text(path)`` round-trips ``\n``, ``\r\n`` and ``\r`` sequences without
+modification.  ``FileNotFoundError`` and other I/O errors propagate to the
+caller.
 """
+
+from __future__ import annotations
+
+import os
+
+PathLikeStr = os.PathLike[str]
+
+
+def read_text(
+    path: str | PathLikeStr,
+    *,
+    encoding: str = "utf-8-sig",
+    errors: str = "strict",
+) -> str:
+    """Read a plain-text file as-is.
+
+    Parameters
+    ----------
+    path:
+        Path to the file on disk.
+    encoding:
+        Text encoding to use.  Defaults to ``"utf-8-sig"`` so that a UTF-8 BOM
+        is consumed when present.
+    errors:
+        Error handling strategy passed to :func:`open`.
+
+    Returns
+    -------
+    str
+        The file contents without any newline translation.
+
+    Notes
+    -----
+    ``newline=""`` is used when opening the file to prevent Python from
+    converting newline characters.  This function performs no normalization of
+    whitespace or line endings.
+    """
+
+    with open(path, "r", encoding=encoding, errors=errors, newline="") as f:
+        return f.read()
+
+
+__all__ = ["read_text"]

--- a/src/redactor/io/writers/txt_writer.py
+++ b/src/redactor/io/writers/txt_writer.py
@@ -1,22 +1,52 @@
-"""Plain text writer.
+"""Plain-text writer.
 
-Purpose:
-    Output redacted text to UTF-8 encoded files.
+The :func:`write_text` helper persists Unicode strings to disk without altering
+existing newline sequences.  Directories required to store the file are created
+automatically.  By default UTF-8 encoding without a BOM is used.
 
-Key responsibilities:
-    - Write text to disk.
-    - Ensure newline and encoding consistency.
-
-Inputs/Outputs:
-    - Inputs: text string, output path.
-    - Outputs: created file on disk.
-
-Public contracts (planned):
-    - `write_text(text, path)`: Persist text to file.
-
-Notes/Edge cases:
-    - Existing files may need overwrite confirmation.
-
-Dependencies:
-    - `pathlib`.
+This module performs *no* content normalization; the ``text`` argument is
+written exactly as provided.
 """
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+PathLikeStr = os.PathLike[str]
+
+
+def write_text(
+    path: str | PathLikeStr,
+    text: str,
+    *,
+    encoding: str = "utf-8",
+    newline: str | None = "",
+) -> None:
+    """Write ``text`` to ``path`` exactly as provided.
+
+    Parameters
+    ----------
+    path:
+        Destination file path.
+    text:
+        The Unicode string to be written.
+    encoding:
+        Output encoding.  Defaults to UTF-8 without a byte-order mark.
+    newline:
+        ``newline`` parameter forwarded to :func:`open`.  The default of ``""``
+        ensures newline characters in ``text`` are emitted verbatim.
+
+    Notes
+    -----
+    Parent directories are created with ``exist_ok=True``.  This function
+    performs no normalization or mutation of the provided text.
+    """
+
+    file_path = Path(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(file_path, "w", encoding=encoding, newline=newline) as f:
+        f.write(text)
+
+
+__all__ = ["write_text"]

--- a/src/redactor/utils/errors.py
+++ b/src/redactor/utils/errors.py
@@ -1,4 +1,4 @@
-"""Typed exceptions for span validation and manipulation."""
+"""Typed exceptions for span validation/manipulation and I/O formats."""
 
 
 class SpanError(ValueError):
@@ -11,3 +11,11 @@ class OverlapError(SpanError):
 
 class SpanOutOfBoundsError(SpanError):
     """Raised when span coordinates are invalid or out of bounds."""
+
+
+class IOFormatError(ValueError):
+    """Base class for I/O format related errors."""
+
+
+class UnsupportedFormatError(IOFormatError):
+    """Raised when no reader or writer is registered for a file format."""

--- a/tests/test_io_registry.py
+++ b/tests/test_io_registry.py
@@ -1,0 +1,31 @@
+"""Tests for the extension-based I/O registry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from redactor.io import read_file, write_file
+from redactor.utils.errors import UnsupportedFormatError
+
+
+def test_unknown_extension_raises(tmp_path: Path) -> None:
+    path = tmp_path / "file.unknown"
+    with pytest.raises(UnsupportedFormatError):
+        read_file(path)
+    with pytest.raises(UnsupportedFormatError):
+        write_file(path, "text")
+
+
+def test_txt_roundtrip_via_registry(tmp_path: Path) -> None:
+    content = "hello"
+    path = tmp_path / "sample.txt"
+    write_file(path, content)
+    assert read_file(path) == content
+
+
+def test_extension_case_insensitive(tmp_path: Path) -> None:
+    path = tmp_path / "SAMPLE.TXT"
+    write_file(path, "hi")
+    assert read_file(path) == "hi"

--- a/tests/test_io_txt_roundtrip.py
+++ b/tests/test_io_txt_roundtrip.py
@@ -1,0 +1,30 @@
+"""Tests for plain-text reader and writer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from redactor.io.readers.txt_reader import read_text
+from redactor.io.writers.txt_writer import write_text
+
+
+def test_txt_roundtrip_preserves_mixed_newlines(tmp_path: Path) -> None:
+    content = "A\nB\r\nC\rD"
+    file_path = tmp_path / "sample.txt"
+    write_text(file_path, content)
+    assert read_text(file_path) == content
+
+
+def test_read_text_handles_utf8_bom(tmp_path: Path) -> None:
+    content = "hello"
+    file_path = tmp_path / "bom.txt"
+    with open(file_path, "w", encoding="utf-8-sig", newline="") as f:
+        f.write(content)
+    assert read_text(file_path) == content
+
+
+def test_write_text_creates_parent_dirs(tmp_path: Path) -> None:
+    file_path = tmp_path / "nested" / "dir" / "file.txt"
+    write_text(file_path, "data")
+    assert file_path.exists()
+    assert read_text(file_path) == "data"


### PR DESCRIPTION
## Summary
- implement plain text read/write helpers preserving newlines and BOMs
- introduce extension-based I/O registry with custom errors
- add tests verifying text round-trip and registry dispatch

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools)*
- `ruff check .`
- `black --check .`
- `mypy .` *(fails: Library stubs not installed for "yaml"; Cannot find module "pydantic")*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'redactor')*
- `PYTHONPATH=src pytest tests/test_io_registry.py tests/test_io_txt_roundtrip.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3316da6ac8325bf1387b60e8c278e