### PR TITLE
feat(pseudo): add deterministic seeding and stable ID utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ pseudonym seed are provided via environment variables; set
 `REDACTOR_SEED_SECRET` (or a custom variable defined by
 `pseudonyms.seed.secret_env`) to deterministically seed pseudonyms.
 
+## Deterministic seeding
+
+Seeding controls how identifiers and random number generators are derived from
+input text. By default, identifiers are scoped to each document, so the same
+person in two files receives different pseudonyms. Setting
+`pseudonyms.cross_doc_consistency` to `true` switches to global scoping where
+the same entity maps to the same pseudonym across documents.
+
+Provide a secret via the `REDACTOR_SEED_SECRET` environment variable (or the
+name configured in `pseudonyms.seed.secret_env`) to cryptographically tie these
+values to your deployment. Omitting the secret still yields deterministic
+output but without cryptographic protection.
+
 ## Quick start (CLI)
 
 ```bash

--- a/src/redactor/pseudo/__init__.py
+++ b/src/redactor/pseudo/__init__.py
@@ -1,1 +1,23 @@
 """Pseudonymization utilities for generating surrogate data."""
+
+from .seed import (
+    canonicalize_key,
+    doc_hash,
+    doc_scope,
+    get_secret_bytes,
+    rng_for,
+    scoped_rng_for_text,
+    scoped_stable_id_for_text,
+    stable_id,
+)
+
+__all__ = [
+    "canonicalize_key",
+    "doc_hash",
+    "doc_scope",
+    "get_secret_bytes",
+    "rng_for",
+    "scoped_rng_for_text",
+    "scoped_stable_id_for_text",
+    "stable_id",
+]

--- a/src/redactor/pseudo/seed.py
+++ b/src/redactor/pseudo/seed.py
@@ -1,22 +1,221 @@
-"""Pseudorandom seed management.
+"""Deterministic seeding helpers for pseudonymization.
 
-Purpose:
-    Provide deterministic seeding for pseudonym generation.
+This module derives stable identifiers and reproducible random streams from a
+user-provided secret using HMAC-SHA256 with strict domain separation.  Entity
+keys are canonicalized to avoid variations in case or whitespace from affecting
+hashes.  Scopes can be per-document or cross-document depending on
+configuration, enabling deterministic yet isolated pseudonyms.
 
-Key responsibilities:
-    - Derive seeds using HMAC with a secret key.
-    - Ensure reproducibility across runs without exposing the secret.
+These helpers only yield opaque identifiers and RNG seeds.  Higher-level
+pseudonym generators interpret them to produce human-readable surrogates.
 
-Inputs/Outputs:
-    - Inputs: secret from environment, optional user identifier.
-    - Outputs: integer seed values for random generators.
-
-Public contracts (planned):
-    - `derive_seed(key_material)`: Return deterministic seed.
-
-Notes/Edge cases:
-    - Secret key must never be persisted; environment only.
-
-Dependencies:
-    - `hashlib` and `hmac` from standard library.
+Security notes
+--------------
+A non-empty secret provides cryptographically strong determinism.  When the
+secret is omitted, functions fall back to unkeyed hashes; this is predictable
+and suitable only for non-sensitive scenarios.  Secrets and derived digests are
+never logged or exposed.
 """
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import random
+import re
+import unicodedata
+from typing import Final
+
+from redactor.config import ConfigModel
+
+# ---------------------------------------------------------------------------
+# Domain separation constants
+# ---------------------------------------------------------------------------
+
+_NS_DOC: Final = b"redactor/v1/doc-seed"
+_NS_ENTITY: Final = b"redactor/v1/entity"
+_NS_RNG: Final = b"redactor/v1/rng"
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization
+# ---------------------------------------------------------------------------
+
+
+def canonicalize_key(key: str) -> str:
+    """Normalize an entity key for hashing.
+
+    The normalization steps are:
+
+    - strip leading/trailing whitespace
+    - collapse internal whitespace runs to a single space
+    - lowercase
+    - NFC normalize (not NFKC)
+    """
+
+    normalized = unicodedata.normalize("NFC", key.strip())
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized.lower()
+
+
+# ---------------------------------------------------------------------------
+# Document hashing
+# ---------------------------------------------------------------------------
+
+
+def doc_hash(text: str) -> bytes:
+    """Return a 32-byte BLAKE2b digest of the raw document text."""
+
+    return hashlib.blake2b(text.encode("utf-8"), digest_size=32).digest()
+
+
+# ---------------------------------------------------------------------------
+# Secret extraction
+# ---------------------------------------------------------------------------
+
+
+def get_secret_bytes(cfg: ConfigModel, *, require: bool = False) -> bytes:
+    """Return the seed secret as bytes.
+
+    Parameters
+    ----------
+    cfg:
+        Configuration model holding the pseudonym seed.
+    require:
+        If ``True`` and the secret is missing, ``ValueError`` is raised.
+
+    Notes
+    -----
+    An empty secret reduces security; callers may choose ``require=True`` in
+    stricter modes.  This function never logs or prints the secret.
+    """
+
+    secret = cfg.pseudonyms.seed.secret
+    if secret is None:
+        if require:
+            raise ValueError("Missing pseudonym seed secret")
+        return b""
+    return secret.get_secret_value().encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Scope derivation
+# ---------------------------------------------------------------------------
+
+
+def doc_scope(cfg: ConfigModel, *, text: str | None) -> bytes:
+    """Derive a document scope digest.
+
+    If ``cfg.pseudonyms.cross_doc_consistency`` is ``False``:
+        return HMAC(secret, ``_NS_DOC`` || ``doc_hash(text)``)
+    Else:
+        return HMAC(secret, ``_NS_DOC`` || ``b"GLOBAL"``)
+    If secret is empty, fall back to ``doc_hash(text)`` / ``b"GLOBAL"``.
+    """
+
+    secret = get_secret_bytes(cfg, require=False)
+    if cfg.pseudonyms.cross_doc_consistency:
+        data = _NS_DOC + b"GLOBAL"
+        if secret:
+            return hmac.new(secret, data, hashlib.sha256).digest()
+        return b"GLOBAL"
+
+    if text is None:
+        raise ValueError("Document text required when cross_doc_consistency is False")
+    doc_digest = doc_hash(text)
+    data = _NS_DOC + doc_digest
+    if secret:
+        return hmac.new(secret, data, hashlib.sha256).digest()
+    return doc_digest
+
+
+# ---------------------------------------------------------------------------
+# Stable identifiers
+# ---------------------------------------------------------------------------
+
+
+def stable_id(
+    kind: str,
+    key: str,
+    *,
+    cfg: ConfigModel,
+    scope: bytes,
+    length: int = 20,
+) -> str:
+    """Return a stable, non-reversible identifier token.
+
+    The token is computed as ``HMAC(secret, _NS_ENTITY || kind || scope ||
+    canonicalized_key)`` and rendered as URL-safe lowercase Base32 without
+    padding.  When the secret is empty, SHA256 over the same concatenation is
+    used instead.
+    """
+
+    if not 8 <= length <= 52:
+        raise ValueError("length must be between 8 and 52")
+
+    canonical = canonicalize_key(key)
+    data = _NS_ENTITY + kind.encode("utf-8") + scope + canonical.encode("utf-8")
+    secret = get_secret_bytes(cfg, require=False)
+    if secret:
+        digest = hmac.new(secret, data, hashlib.sha256).digest()
+    else:
+        digest = hashlib.sha256(data).digest()
+
+    token = base64.b32encode(digest).decode("ascii").lower().rstrip("=")
+    return token[:length]
+
+
+# ---------------------------------------------------------------------------
+# Reproducible RNG
+# ---------------------------------------------------------------------------
+
+
+def rng_for(kind: str, key: str, *, cfg: ConfigModel, scope: bytes) -> random.Random:
+    """Derive a reproducible RNG seeded from the provided parameters."""
+
+    canonical = canonicalize_key(key)
+    data = _NS_RNG + kind.encode("utf-8") + scope + canonical.encode("utf-8")
+    secret = get_secret_bytes(cfg, require=False)
+    if secret:
+        digest = hmac.new(secret, data, hashlib.sha256).digest()
+    else:
+        digest = hashlib.sha256(data).digest()
+    seed_int = int.from_bytes(digest, "big")
+    return random.Random(seed_int)
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers
+# ---------------------------------------------------------------------------
+
+
+def scoped_stable_id_for_text(
+    kind: str,
+    key: str,
+    text: str,
+    cfg: ConfigModel,
+    *,
+    length: int = 20,
+) -> str:
+    """Stable identifier for ``key`` scoped to ``text`` using ``cfg``."""
+
+    return stable_id(kind, key, cfg=cfg, scope=doc_scope(cfg, text=text), length=length)
+
+
+def scoped_rng_for_text(kind: str, key: str, text: str, cfg: ConfigModel) -> random.Random:
+    """Reproducible RNG for ``key`` scoped to ``text`` using ``cfg``."""
+
+    return rng_for(kind, key, cfg=cfg, scope=doc_scope(cfg, text=text))
+
+
+__all__ = [
+    "canonicalize_key",
+    "doc_hash",
+    "get_secret_bytes",
+    "doc_scope",
+    "stable_id",
+    "rng_for",
+    "scoped_stable_id_for_text",
+    "scoped_rng_for_text",
+]

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pydantic import SecretStr
+
+from redactor.config import ConfigModel, load_config
+from redactor.pseudo import (
+    canonicalize_key,
+    scoped_rng_for_text,
+    scoped_stable_id_for_text,
+)
+
+
+def cfg_with_secret(s: str, cross_doc: bool = False) -> ConfigModel:
+    cfg = load_config()
+    seed = cfg.pseudonyms.seed.model_copy(update={"secret": SecretStr(s)})
+    pseudo = cfg.pseudonyms.model_copy(update={"cross_doc_consistency": cross_doc, "seed": seed})
+    return cfg.model_copy(update={"pseudonyms": pseudo})
+
+
+def test_determinism() -> None:
+    cfg = cfg_with_secret("alpha")
+    text_a = "document a"
+    id1 = scoped_stable_id_for_text("PERSON", "John   Doe", text_a, cfg)
+    id2 = scoped_stable_id_for_text("PERSON", "john doe", text_a, cfg)
+    assert id1 == id2
+    assert len(id1) == 20
+
+
+def test_secret_sensitivity() -> None:
+    text = "doc"
+    cfg_a = cfg_with_secret("alpha")
+    cfg_b = cfg_with_secret("beta")
+    id_a = scoped_stable_id_for_text("EMAIL", "john@example.com", text, cfg_a)
+    id_b = scoped_stable_id_for_text("EMAIL", "john@example.com", text, cfg_b)
+    assert id_a != id_b
+
+
+def test_scope_behavior() -> None:
+    cfg_doc = cfg_with_secret("alpha", cross_doc=False)
+    id_doc1 = scoped_stable_id_for_text("PERSON", "jane doe", "doc1", cfg_doc)
+    id_doc2 = scoped_stable_id_for_text("PERSON", "jane doe", "doc2", cfg_doc)
+    assert id_doc1 != id_doc2
+
+    cfg_global = cfg_with_secret("alpha", cross_doc=True)
+    id_gl1 = scoped_stable_id_for_text("PERSON", "jane doe", "doc1", cfg_global)
+    id_gl2 = scoped_stable_id_for_text("PERSON", "jane doe", "doc2", cfg_global)
+    assert id_gl1 == id_gl2
+
+
+def test_rng_determinism() -> None:
+    cfg_doc = cfg_with_secret("alpha", cross_doc=False)
+    r1 = scoped_rng_for_text("ADDRESS", "366 broadway", "doc1", cfg_doc)
+    r2 = scoped_rng_for_text("ADDRESS", "366 broadway", "doc1", cfg_doc)
+    assert [r1.random() for _ in range(3)] == [r2.random() for _ in range(3)]
+
+
+def test_canonicalize_key() -> None:
+    assert canonicalize_key("  JOHN \t DOE ") == "john doe"
+
+
+def test_empty_secret_fallback() -> None:
+    cfg = load_config()
+    text = "doc"
+    id1 = scoped_stable_id_for_text("PERSON", "jane doe", text, cfg)
+    id2 = scoped_stable_id_for_text("PERSON", "jane doe", text, cfg)
+    assert id1 == id2


### PR DESCRIPTION
## Summary
- implement scoped hashing utilities for deterministic pseudonym seeds and IDs
- expose seeding helpers in pseudo package and document configuration
- cover deterministic IDs, scope behavior, RNG, and canonicalization in tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b33ae2edc083258646b0f7e5cff463