### PR TITLE
feat(pseudo): add case/format preservation utilities (casing, initials, punctuation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ name configured in `pseudonyms.seed.secret_env`) to cryptographically tie these
 values to your deployment. Omitting the secret still yields deterministic
 output but without cryptographic protection.
 
+## Case and format preservation
+
+Pseudonym replacements mirror the casing and punctuation shape of the source
+text.  Generated names adapt to match initials patterns and interior
+punctuation, keeping the redacted output natural.  For example, a source token
+like ``O’NEIL`` would become ``D’ANGELO`` when replaced.
+
 ## Quick start (CLI)
 
 ```bash

--- a/src/redactor/pseudo/case_preserver.py
+++ b/src/redactor/pseudo/case_preserver.py
@@ -1,22 +1,262 @@
-"""Case preservation helpers.
+"""Utilities for preserving case and formatting of pseudonym replacements.
 
-Purpose:
-    Maintain original casing patterns when substituting pseudonyms.
+This module adapts generated replacement strings so that they resemble the
+original spans.  It is intentionally lightweight and relies only on the
+standard library.  The helpers are pure and deterministic; any required
+randomness must be supplied by the caller via :class:`random.Random`.
 
-Key responsibilities:
-    - Analyze casing of source tokens.
-    - Apply similar casing to generated pseudonyms.
+Responsibilities
+----------------
+* Mirror the casing of the source text on the replacement.
+* Preserve surrounding punctuation such as quotes or brackets.
+* Re‑insert interior punctuation (apostrophes, hyphens, periods, spaces)
+  according to the positions found in the source.
+* Handle initials‑only patterns (e.g. ``"J.D."`` or ``"J. D."``).
+* Carry over possessive suffixes (``'s`` or ``’s``) when present.
 
-Inputs/Outputs:
-    - Inputs: original text, pseudonym.
-    - Outputs: pseudonym adjusted for case.
+The module does **not** decide which tokens to use for a pseudonym – that is
+the responsibility of the caller.  It only adjusts the supplied replacement so
+that it matches the *shape* of the original span.
 
-Public contracts (planned):
-    - `preserve_case(source, replacement)`: Return case-adjusted replacement.
-
-Notes/Edge cases:
-    - Mixed-case tokens require per-character analysis.
-
-Dependencies:
-    - Standard library only.
+If the source contains no alphabetic characters the formatting utilities
+return the replacement unchanged (aside from outer punctuation preservation).
+When calculating punctuation positions only alphabetic characters advance the
+letter offset; digits are ignored for this purpose.
 """
+
+from __future__ import annotations
+
+import random
+import re
+import string
+from typing import List, Optional, Sequence, Tuple
+
+from redactor.utils.textspan import detect_text_case
+
+
+def match_case(source: str, replacement: str) -> str:
+    """Return ``replacement`` with casing adapted from ``source``.
+
+    If ``source`` is uniformly ``UPPER``/``LOWER``/``TITLE`` (as detected by
+    :func:`redactor.utils.textspan.detect_text_case`), apply that casing to the
+    entire ``replacement``.  Otherwise a character‑wise mapping is performed
+    where each alphabetic character in ``replacement`` copies the case of the
+    corresponding alphabetic character in ``source``.  When the strings have
+    different numbers of letters the source pattern is cycled.
+    Non‑alphabetic characters in ``replacement`` are left untouched.
+    """
+
+    case = detect_text_case(source)
+    if case == "UPPER":
+        return replacement.upper()
+    if case == "LOWER":
+        return replacement.lower()
+    if case == "TITLE":
+        return replacement.title()
+
+    # Mixed case: map letter by letter.
+    source_letters = [ch for ch in source if ch.isalpha()]
+    if not source_letters:
+        return replacement
+
+    result: List[str] = []
+    idx = 0
+    for ch in replacement:
+        if ch.isalpha():
+            src_ch = source_letters[idx % len(source_letters)]
+            idx += 1
+            result.append(ch.upper() if src_ch.isupper() else ch.lower())
+        else:
+            result.append(ch)
+    return "".join(result)
+
+
+_INITIALS_RE = re.compile(r"^(?:[A-Za-z][.\- ]+)+[A-Za-z][.]?\Z")
+
+
+def format_like(source: str, replacement: str, *, rng: Optional[random.Random] = None) -> str:
+    """Format ``replacement`` so it mirrors ``source``.
+
+    The function preserves outer punctuation, interior punctuation placement,
+    possessive suffixes and casing.  If ``source`` is an initials‑only pattern
+    (e.g. ``"J.D."`` or ``"J. D."``) initials are generated from
+    ``replacement`` using :func:`preserve_initials`.
+
+    For strings without alphabetic characters the ``replacement`` is returned
+    unchanged apart from outer punctuation retention.
+    """
+
+    if _INITIALS_RE.fullmatch(source):
+        return preserve_initials(source, replacement, rng=rng)
+
+    prefix, core, suffix = extract_outer_punct(source)
+
+    if not any(ch.isalpha() for ch in core):
+        return prefix + replacement + suffix
+
+    poss_suffix = ""
+    core_work = core
+    for suff in ("'s", "'S", "’s", "’S"):
+        if core_work.endswith(suff):
+            poss_suffix = suff
+            core_work = core_work[: -len(suff)]
+            break
+
+    profile = letter_punct_profile(core_work)
+
+    # When the replacement contains token boundaries (spaces), try to align
+    # punctuation with those boundaries so hyphenated sources map to hyphenated
+    # replacements rather than splitting tokens mid-letter.
+    tokens = [t for t in replacement.split() if t]
+    boundaries: list[int] = []
+    count = 0
+    for tok in tokens[:-1]:
+        count += sum(1 for ch in tok if ch.isalpha())
+        boundaries.append(count)
+    adjusted: list[tuple[int, str]] = []
+    for offset, punct in profile:
+        new_offset = offset
+        for boundary in boundaries:
+            if offset < boundary:
+                new_offset = boundary
+                break
+        adjusted.append((new_offset, punct))
+
+    base = "".join(ch for ch in replacement if ch.isalnum())
+    with_punct = apply_letter_punct_profile(base, adjusted)
+    cased = match_case(core_work, with_punct)
+    if poss_suffix:
+        cased += poss_suffix
+    return prefix + cased + suffix
+
+
+def preserve_initials(
+    source: str, replacement_full: str, *, rng: Optional[random.Random] = None
+) -> str:
+    """Return initials shaped like ``source`` derived from ``replacement_full``.
+
+    ``source`` must be a sequence of single letters optionally separated by
+    dots, spaces or hyphens.  The exact separator pattern – including spacing –
+    is preserved.  If ``replacement_full`` provides fewer tokens than required
+    initials, additional letters are generated.  A ``rng`` may be supplied for
+    deterministic synthesis; if omitted the last available initial is reused.
+    """
+
+    letters: List[str] = []
+    seps: List[str] = []
+    buf = ""
+    for ch in source:
+        if ch.isalpha():
+            letters.append(ch)
+            if buf:
+                seps.append(buf)
+                buf = ""
+        elif ch in ".- ":
+            buf += ch
+        else:
+            # Not an initials pattern
+            return match_case(source, replacement_full)
+    seps.append(buf)
+
+    if not letters:
+        return replacement_full
+
+    tokens = re.findall(r"[^\W\d_]+", replacement_full, flags=re.UNICODE)
+    initials = [t[0] for t in tokens]
+    if not initials:
+        initials = ["A"]
+
+    if len(initials) < len(letters):
+        deficit = len(letters) - len(initials)
+        if rng is not None:
+            initials.extend(rng.choice(string.ascii_uppercase) for _ in range(deficit))
+        else:
+            initials.extend(initials[-1] for _ in range(deficit))
+    else:
+        initials = initials[: len(letters)]
+
+    built = "".join(ch + sep for ch, sep in zip(initials, seps, strict=False))
+    return match_case(source, built)
+
+
+def extract_outer_punct(source: str) -> Tuple[str, str, str]:
+    """Return ``(prefix, core, suffix)`` separating outer punctuation.
+
+    ``prefix`` and ``suffix`` are contiguous runs of non‑alphanumeric characters
+    from the start and end of ``source`` respectively.  ``core`` is the middle
+    portion.
+    """
+
+    start = 0
+    end = len(source)
+    while start < end and not source[start].isalnum():
+        start += 1
+    while end > start and not source[end - 1].isalnum():
+        end -= 1
+    return source[:start], source[start:end], source[end:]
+
+
+def letter_punct_profile(source: str) -> List[Tuple[int, str]]:
+    """Return interior punctuation positions for ``source``.
+
+    The result is a list of ``(letter_offset, punct)`` tuples where
+    ``letter_offset`` counts only alphabetic characters.  Punctuation sequences
+    (including spaces) between letters are recorded.  If ``source`` ends with
+    punctuation after the final letter it is also included.
+    """
+
+    profile: List[Tuple[int, str]] = []
+    letter_offset = 0
+    buf = ""
+    for ch in source:
+        if ch.isalpha():
+            if buf:
+                profile.append((letter_offset, buf))
+                buf = ""
+            letter_offset += 1
+        else:
+            buf += ch
+    if buf:
+        profile.append((letter_offset, buf))
+    return profile
+
+
+def apply_letter_punct_profile(replacement_core: str, profile: Sequence[Tuple[int, str]]) -> str:
+    """Insert punctuation defined by ``profile`` into ``replacement_core``.
+
+    ``profile`` is typically produced by :func:`letter_punct_profile` and
+    contains pairs of ``(letter_offset, punct)``.  ``letter_offset`` counts only
+    alphabetic characters.  If an offset exceeds the number of available
+    letters the punctuation is appended at the end.
+    """
+
+    if not profile:
+        return replacement_core
+
+    result: List[str] = []
+    letters_seen = 0
+    prof_iter = iter(sorted(profile, key=lambda x: x[0]))
+    current = next(prof_iter, None)
+
+    for ch in replacement_core:
+        while current and letters_seen == current[0]:
+            result.append(current[1])
+            current = next(prof_iter, None)
+        result.append(ch)
+        if ch.isalpha():
+            letters_seen += 1
+
+    while current:
+        result.append(current[1])
+        current = next(prof_iter, None)
+    return "".join(result)
+
+
+__all__ = [
+    "match_case",
+    "format_like",
+    "preserve_initials",
+    "extract_outer_punct",
+    "letter_punct_profile",
+    "apply_letter_punct_profile",
+]

--- a/tests/test_case_preserver.py
+++ b/tests/test_case_preserver.py
@@ -1,0 +1,64 @@
+"""Tests for case and format preservation utilities."""
+
+from __future__ import annotations
+
+import importlib.util
+import random
+import sys
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "src" / "redactor" / "pseudo" / "case_preserver.py"
+)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+spec = importlib.util.spec_from_file_location("case_preserver", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+case_preserver = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(case_preserver)
+
+match_case = case_preserver.match_case
+format_like = case_preserver.format_like
+
+
+def test_match_case_global() -> None:
+    assert match_case("JOHN DOE", "Alex Carter") == "ALEX CARTER"
+    assert match_case("john doe", "Alex Carter") == "alex carter"
+    assert match_case("John Doe", "alex carter") == "Alex Carter"
+
+
+def test_match_case_mixed_letterwise() -> None:
+    assert match_case("McDONALD", "Smithson") == "SmITHSON"
+
+
+def test_format_like_interior_punctuation() -> None:
+    assert format_like("O'NEIL", "Dangelo") == "D'ANGELO"
+    assert format_like("SMITH-JONES", "Carter Green") == "CARTER-GREEN"
+
+
+def test_format_like_surrounding_punctuation() -> None:
+    assert format_like("\u201cJohn\u201d", "Alex") == "\u201cAlex\u201d"
+    assert format_like("(John)", "Alex") == "(Alex)"
+
+
+def test_format_like_possessive() -> None:
+    assert format_like("John's", "Alex") == "Alex's"
+
+
+def test_format_like_initials_preservation() -> None:
+    assert format_like("J.D.", "Alex Carter") == "A.C."
+    assert format_like("J. D.", "Alex Carter") == "A. C."
+    assert format_like("J.D.E.", "Alex C. Thompson") == "A.C.T."
+    assert format_like("J.D.", "Alex") == "A.A."
+
+
+def test_format_like_initials_rng_deterministic() -> None:
+    seed = 123
+    assert (
+        format_like("J.D.", "Alex", rng=random.Random(seed))
+        == format_like("J.D.", "Alex", rng=random.Random(seed))
+        == "A.B."
+    )
+
+
+def test_format_like_non_letter_string() -> None:
+    assert format_like("123-456", "789-012") == "789-012"


### PR DESCRIPTION
## Summary
- add utilities to preserve casing, initials, and punctuation when generating pseudonyms
- document case and format preservation in README
- test case/format preservation helpers

## Testing
- `ruff check .`
- `black --check .`
- `pytest tests/test_case_preserver.py -q`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "pydantic")*


------
https://chatgpt.com/codex/tasks/task_e_68b33c8c9af48325a12fd27c93699cae