### PR TITLE
feat(pseudo): add central pseudonym generator with deterministic stub outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ name configured in `pseudonyms.seed.secret_env`) to cryptographically tie these
 values to your deployment. Omitting the secret still yields deterministic
 output but without cryptographic protection.
 
+## Pseudonym generator (stub)
+
+The current pseudonym generator maps each entity to a deterministic placeholder
+such as `PERSON_xxxxx` or `ORG_xxxxx`. These tokens are stable for a given
+configuration and scope but are clearly fake. Future milestones will introduce
+shape-preserving fakes and integrate them with case/format preservation.
+
 ## Case and format preservation
 
 Pseudonym replacements mirror the casing and punctuation shape of the source

--- a/src/redactor/pseudo/__init__.py
+++ b/src/redactor/pseudo/__init__.py
@@ -1,5 +1,6 @@
 """Pseudonymization utilities for generating surrogate data."""
 
+from .generator import PseudonymGenerator
 from .seed import (
     canonicalize_key,
     doc_hash,
@@ -12,6 +13,7 @@ from .seed import (
 )
 
 __all__ = [
+    "PseudonymGenerator",
     "canonicalize_key",
     "doc_hash",
     "doc_scope",

--- a/src/redactor/pseudo/generator.py
+++ b/src/redactor/pseudo/generator.py
@@ -1,22 +1,96 @@
-"""Pseudonym generator.
+"""Deterministic pseudonym generator stubs.
 
-Purpose:
-    Produce consistent surrogate values for detected entities.
+This module provides a lightweight :class:`PseudonymGenerator` that maps an
+entity's canonical key to a deterministic placeholder token.  The generator is
+seeded from a :class:`~redactor.config.ConfigModel` and a document scope so that
+the same configuration, scope and key always yield the same pseudonym.
 
-Key responsibilities:
-    - Use seeded random sources to generate pseudonyms.
-    - Support multiple entity types (names, addresses, numbers).
+Security note: generated placeholders are opaque, non-reversible tokens.  They
+currently take simple forms like ``PERSON_xxxxx`` or ``ORG_xxxxx`` and are not
+intended to resemble real data.  Future milestones will swap in realistic,
+shape-preserving fakes.
 
-Inputs/Outputs:
-    - Inputs: entity label, original text, seed.
-    - Outputs: pseudonym string.
-
-Public contracts (planned):
-    - `generate(label, text, seed)`: Return pseudonym for entity.
-
-Notes/Edge cases:
-    - Generated values must avoid real-world collisions.
-
-Dependencies:
-    - `seed` module.
+Relationship to case/format preservation: the raw pseudonyms returned here may
+be passed through :mod:`redactor.pseudo.case_preserver` helpers to mimic the
+casing or punctuation pattern of the original text.
 """
+
+from __future__ import annotations
+
+import random
+
+from redactor.config import ConfigModel
+from .seed import canonicalize_key, doc_scope, rng_for, stable_id
+
+
+class PseudonymGenerator:
+    """Generate deterministic placeholder pseudonyms."""
+
+    def __init__(self, cfg: ConfigModel, *, text: str | None = None, scope: bytes | None = None) -> None:
+        """Initialize the generator.
+
+        Parameters
+        ----------
+        cfg:
+            Configuration used for seeding.
+        text:
+            Raw document text.  Required when ``scope`` is ``None`` and
+            ``cfg.pseudonyms.cross_doc_consistency`` is ``False``.
+        scope:
+            Optional precomputed scope digest.  If omitted, it is derived from
+            ``cfg`` and ``text`` via :func:`redactor.pseudo.seed.doc_scope`.
+        """
+
+        if scope is None:
+            scope = doc_scope(cfg, text=text)
+        self.cfg: ConfigModel = cfg
+        self.scope: bytes = scope
+
+    def token(self, kind: str, key: str, *, length: int = 12) -> str:
+        """Return a stable token suffix for ``key`` of a given ``kind``."""
+
+        canonical = canonicalize_key(key)
+        return stable_id(kind, canonical, cfg=self.cfg, scope=self.scope, length=length)
+
+    def rng(self, kind: str, key: str) -> random.Random:
+        """Return a reproducible random number generator for ``key``."""
+
+        canonical = canonicalize_key(key)
+        return rng_for(kind, canonical, cfg=self.cfg, scope=self.scope)
+
+    def person_name(self, key: str) -> str:
+        """Return a deterministic placeholder for a person name."""
+
+        return f"PERSON_{self.token('PERSON', key)}"
+
+    def org_name(self, key: str) -> str:
+        """Return a deterministic placeholder for an organization name."""
+
+        return f"ORG_{self.token('ORG', key)}"
+
+    def bank_org_name(self, key: str) -> str:
+        """Return a deterministic placeholder for a bank organization name."""
+
+        return f"BANK_{self.token('BANK_ORG', key)}"
+
+    def email(self, key: str) -> str:
+        """Return a deterministic placeholder e-mail address."""
+
+        return f"u{self.token('EMAIL', key, length=10)}@example.org"
+
+    def phone(self, key: str) -> str:
+        """Return a deterministic E.164-like US phone number placeholder."""
+
+        rng = self.rng('PHONE', key)
+        seven = rng.randint(0, 9_999_999)
+        return f"+1555{seven:07d}"
+
+    def address(self, key: str) -> str:
+        """Return a deterministic placeholder for an address block."""
+
+        return f"ADDRESS_{self.token('ADDRESS_BLOCK', key)}"
+
+    def account_number(self, key: str, kind: str = "generic") -> str:
+        """Return a deterministic placeholder account number."""
+
+        return f"ACCT_{self.token(f'ACCOUNT_{kind}', key, length=16)}"

--- a/tests/test_pseudonym_generator_stubs.py
+++ b/tests/test_pseudonym_generator_stubs.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+from __future__ import annotations
+
+import re
+
+from pydantic import SecretStr
+
+from redactor.config import ConfigModel, load_config
+from redactor.pseudo import PseudonymGenerator
+
+
+def cfg_with_secret(s: str, cross_doc: bool = False) -> ConfigModel:
+    cfg = load_config()
+    seed = cfg.pseudonyms.seed.model_copy(update={"secret": SecretStr(s)})
+    pseudo = cfg.pseudonyms.model_copy(update={"cross_doc_consistency": cross_doc, "seed": seed})
+    return cfg.model_copy(update={"pseudonyms": pseudo})
+
+
+def test_determinism_within_document() -> None:
+    gen = PseudonymGenerator(cfg_with_secret("alpha"), text="doc A")
+    assert gen.person_name("John Doe") == gen.person_name("john  doe")
+    assert gen.person_name("John Doe").startswith("PERSON_")
+    assert gen.org_name("Acme Inc.") != gen.person_name("Acme Inc.")
+    assert gen.email("john@example.com").endswith("@example.org")
+    assert re.fullmatch(r"\+1555\d{7}", gen.phone("555-1212"))
+    assert gen.address("366 Broadway").startswith("ADDRESS_")
+    assert gen.account_number("123456789").startswith("ACCT_")
+
+
+def test_scope_behavior_per_doc() -> None:
+    gen_a = PseudonymGenerator(cfg_with_secret("alpha", cross_doc=False), text="doc A")
+    gen_b = PseudonymGenerator(cfg_with_secret("alpha", cross_doc=False), text="doc B")
+    assert gen_a.person_name("Jane Doe") != gen_b.person_name("Jane Doe")
+
+
+def test_scope_behavior_cross_doc() -> None:
+    gen1 = PseudonymGenerator(cfg_with_secret("alpha", cross_doc=True), text="doc A")
+    gen2 = PseudonymGenerator(cfg_with_secret("alpha", cross_doc=True), text="doc B")
+    assert gen1.person_name("Jane Doe") == gen2.person_name("Jane Doe")
+
+
+def test_secret_sensitivity() -> None:
+    gen1 = PseudonymGenerator(cfg_with_secret("alpha"), text="doc A")
+    gen2 = PseudonymGenerator(cfg_with_secret("beta"), text="doc A")
+    assert gen1.email("x@y") != gen2.email("x@y")
+
+
+def test_phone_stability() -> None:
+    gen = PseudonymGenerator(cfg_with_secret("alpha"), text="doc A")
+    assert gen.phone("any") == gen.phone("any")
+    assert gen.phone("any") != gen.phone("other")
+
+
+def test_import_export() -> None:
+    from redactor.pseudo import PseudonymGenerator as Exported
+
+    assert Exported is PseudonymGenerator
+


### PR DESCRIPTION
## Summary
- introduce `PseudonymGenerator` with deterministic placeholder tokens for emails, phones, etc.
- expose generator via `redactor.pseudo`
- document stub pseudonym generator in README

## Testing
- `mypy src tests` *(fails: Cannot find implementation or library stub for module named "pydantic")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68b33f3ae7988325879c95af1135ebd0