### PR TITLE
feat(detect): add strict email detector with boundary trimming and attrs

### DIFF
--- a/src/redactor/detect/__init__.py
+++ b/src/redactor/detect/__init__.py
@@ -1,1 +1,5 @@
 """Entity detection components for identifying sensitive information."""
+
+from .email import EmailDetector
+
+__all__ = ["EmailDetector"]

--- a/src/redactor/detect/email.py
+++ b/src/redactor/detect/email.py
@@ -1,22 +1,145 @@
-"""Email address detector.
+"""Strict email address detector.
 
-Purpose:
-    Identify email addresses in text using pattern matching.
+This module provides :class:`EmailDetector`, a high‑precision detector for
+email addresses inspired by RFC5322.  It focuses on accuracy and avoids false
+positives by using a conservative regular expression and additional
+post‑validation.  After a raw regex match, the detector trims trailing
+punctuation that is commonly adjacent to emails in prose and validates domain
+and local parts.  Attributes such as the local part, domain, tag, and top‑level
+ domain are exposed for downstream components.
 
-Key responsibilities:
-    - Apply regex patterns for various email formats.
-    - Emit `EntitySpan` objects labeled as emails.
-
-Inputs/Outputs:
-    - Inputs: text string.
-    - Outputs: list of `EntitySpan` representing emails.
-
-Public contracts (planned):
-    - `detect(text)`: Return spans for email addresses.
-
-Notes/Edge cases:
-    - Should ignore false positives in code blocks or URLs.
-
-Dependencies:
-    - `patterns` module for regexes.
+Notably, IP‑literal domains (e.g. ``user@[1.2.3.4]``) are intentionally
+excluded in favour of precision.
 """
+
+from __future__ import annotations
+
+import re
+
+from .base import DetectionContext, EntityLabel, EntitySpan
+
+__all__ = ["EmailDetector", "get_detector"]
+
+# ---------------------------------------------------------------------------
+# Regular expression
+# ---------------------------------------------------------------------------
+# The pattern is intentionally conservative and only matches dot‑atom or quoted
+# locals with domain names composed of labels and a terminal alphabetic TLD.
+LOCAL_ATOM = r"[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+"
+LOCAL_DOT_ATOM = rf"{LOCAL_ATOM}(?:\.{LOCAL_ATOM})*"
+LOCAL_QUOTED = r'"(?:[^"\\\r\n]|\\.)+"'
+LOCAL_PART = rf"(?:{LOCAL_DOT_ATOM}|{LOCAL_QUOTED})"
+
+DOMAIN_LABEL = r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+TLD = r"[A-Za-z]{2,63}"
+DOMAIN = rf"(?:{DOMAIN_LABEL}\.)+{TLD}"
+
+EMAIL_REGEX = re.compile(
+    rf"""
+    (?<![A-Za-z0-9!#$%&'*+/=?^_`{{|}}~.-])   # ensure preceding boundary
+    ({LOCAL_PART}@{DOMAIN})
+    (?=[^A-Za-z0-9-]|$)                     # ensure following boundary
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+TRAILING_PUNCTUATION = ")],;:,.!?»”’>"
+
+
+def _has_consecutive_dots(value: str) -> bool:
+    return ".." in value
+
+
+def _validate_local(local: str) -> bool:
+    if local.startswith('"') and local.endswith('"'):
+        return True
+    if local.startswith(".") or local.endswith("."):
+        return False
+    if _has_consecutive_dots(local):
+        return False
+    return True
+
+
+def _validate_domain(domain: str) -> bool:
+    if _has_consecutive_dots(domain):
+        return False
+    labels = domain.split(".")
+    if len(labels) < 2:
+        return False
+    tld = labels[-1]
+    if not tld.isalpha() or not (2 <= len(tld) <= 63):
+        return False
+    for label in labels:
+        if not label or label.startswith("-") or label.endswith("-"):
+            return False
+    return True
+
+
+class EmailDetector:
+    """Detect email addresses within text."""
+
+    _confidence: float = 0.99
+
+    def name(self) -> str:  # pragma: no cover - trivial
+        return "email"
+
+    def detect(self, text: str, context: DetectionContext | None = None) -> list[EntitySpan]:
+        """Detect email addresses in ``text``."""
+
+        _ = context
+        spans: list[EntitySpan] = []
+        for match in EMAIL_REGEX.finditer(text):
+            start, end = match.span(1)
+            email_text = match.group(1)
+
+            # Trim trailing punctuation that may neighbour the email in prose.
+            while email_text and email_text[-1] in TRAILING_PUNCTUATION:
+                email_text = email_text[:-1]
+                end -= 1
+
+            local, domain = email_text.rsplit("@", 1)
+            if not (_validate_local(local) and _validate_domain(domain)):
+                continue
+
+            domain_lower = domain.lower()
+            is_quoted = local.startswith('"') and local.endswith('"')
+            if not is_quoted and "+" in local:
+                base_local, tag = local.split("+", 1)
+            else:
+                base_local, tag = local, None
+
+            tld = domain_lower.rsplit(".", 1)[1]
+            attrs = {
+                "local": local,
+                "domain": domain_lower,
+                "normalized": f"{local}@{domain_lower}",
+                "base_local": base_local,
+                "tag": tag,
+                "is_quoted_local": is_quoted,
+                "tld": tld,
+            }
+            spans.append(
+                EntitySpan(
+                    start,
+                    end,
+                    email_text,
+                    EntityLabel.EMAIL,
+                    "email",
+                    self._confidence,
+                    attrs,
+                )
+            )
+
+        # De‑duplicate spans by [start, end)
+        unique: dict[tuple[int, int], EntitySpan] = {}
+        for span in spans:
+            key = (span.start, span.end)
+            if key not in unique:
+                unique[key] = span
+        return sorted(unique.values(), key=lambda s: s.start)
+
+
+def get_detector() -> EmailDetector:
+    """Return an :class:`EmailDetector` instance."""
+
+    return EmailDetector()

--- a/src/redactor/pseudo/generator.py
+++ b/src/redactor/pseudo/generator.py
@@ -20,13 +20,20 @@ from __future__ import annotations
 import random
 
 from redactor.config import ConfigModel
+
 from .seed import canonicalize_key, doc_scope, rng_for, stable_id
 
 
 class PseudonymGenerator:
     """Generate deterministic placeholder pseudonyms."""
 
-    def __init__(self, cfg: ConfigModel, *, text: str | None = None, scope: bytes | None = None) -> None:
+    def __init__(
+        self,
+        cfg: ConfigModel,
+        *,
+        text: str | None = None,
+        scope: bytes | None = None,
+    ) -> None:
         """Initialize the generator.
 
         Parameters
@@ -81,7 +88,7 @@ class PseudonymGenerator:
     def phone(self, key: str) -> str:
         """Return a deterministic E.164-like US phone number placeholder."""
 
-        rng = self.rng('PHONE', key)
+        rng = self.rng("PHONE", key)
         seven = rng.randint(0, 9_999_999)
         return f"+1555{seven:07d}"
 

--- a/tests/test_detect_email.py
+++ b/tests/test_detect_email.py
@@ -1,0 +1,122 @@
+import pytest
+
+from redactor.detect.base import Detector, EntityLabel
+from redactor.detect.email import EmailDetector
+
+
+@pytest.fixture
+def det() -> EmailDetector:
+    return EmailDetector()
+
+
+def test_true_positive_basic(det: EmailDetector) -> None:
+    text = "Contact john.doe@example.com for details."
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.text == "john.doe@example.com"
+    assert span.start == text.index("john.doe@example.com")
+    assert span.attrs["local"] == "john.doe"
+    assert span.attrs["domain"] == "example.com"
+    assert span.attrs["normalized"] == "john.doe@example.com"
+    assert span.attrs["tld"] == "com"
+    assert span.label is EntityLabel.EMAIL
+
+
+def test_true_positive_with_tag(det: EmailDetector) -> None:
+    text = "Send to user+tag@sub.example.co.uk now."
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.attrs["base_local"] == "user"
+    assert span.attrs["tag"] == "tag"
+    assert span.attrs["domain"] == "sub.example.co.uk"
+    assert span.attrs["tld"] == "uk"
+
+
+def test_true_positive_quoted(det: EmailDetector) -> None:
+    text = '"Quoted" <"odd..name"@Example.ORG>'
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.text == '"odd..name"@Example.ORG'
+    assert span.attrs["domain"] == "example.org"
+    assert span.attrs["is_quoted_local"] is True
+    assert span.attrs["normalized"] == '"odd..name"@example.org'
+
+
+def test_true_positive_with_underscore_and_hyphen(det: EmailDetector) -> None:
+    text = "first_last@acme-inc.com"
+    spans = det.detect(text)
+    assert len(spans) == 1
+    assert spans[0].text == "first_last@acme-inc.com"
+
+
+def test_boundary_trimming_parenthesis(det: EmailDetector) -> None:
+    text = "(john@example.org),"
+    spans = det.detect(text)
+    assert spans and spans[0].text == "john@example.org"
+
+
+def test_boundary_trimming_period(det: EmailDetector) -> None:
+    text = "Email: john@example.org."
+    spans = det.detect(text)
+    assert spans and spans[0].text == "john@example.org"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "john@example",
+        "john..doe@example.com",
+        "john.@example.com",
+        "foo@-example.com",
+        "foo@example-.com",
+        "foo@example..com",
+        "Reach me at example.com",
+        "foo @example.com",
+        "foo@bar.c",
+    ],
+)
+def test_negatives(det: EmailDetector, text: str) -> None:
+    assert det.detect(text) == []
+
+
+def test_offsets_and_dedup(det: EmailDetector) -> None:
+    text = "Emails: john@example.com and jane@example.org."
+    spans = det.detect(text)
+    assert [(s.start, s.end) for s in spans] == [
+        (text.index("john@example.com"), text.index("john@example.com") + len("john@example.com")),
+        (text.index("jane@example.org"), text.index("jane@example.org") + len("jane@example.org")),
+    ]
+    assert spans[0].text == "john@example.com"
+    assert spans[1].text == "jane@example.org"
+
+
+def test_repeated_substrings(det: EmailDetector) -> None:
+    text = "john@example.com john@example.com"
+    spans = det.detect(text)
+    assert len(spans) == 2
+    assert len({(s.start, s.end) for s in spans}) == 2
+
+
+def test_case_behaviour(det: EmailDetector) -> None:
+    text = 'Contact "odd..name"@Example.ORG for info.'
+    spans = det.detect(text)
+    assert spans[0].text == '"odd..name"@Example.ORG'
+    assert spans[0].attrs["domain"] == "example.org"
+    assert spans[0].attrs["normalized"] == '"odd..name"@example.org'
+    assert spans[0].attrs["local"] == '"odd..name"'
+
+
+def test_detector_integration() -> None:
+    det = EmailDetector()
+    assert isinstance(det, Detector)
+    text = "Reach us at support@example.com or sales@example.org"
+    spans = det.detect(text)
+    seen: set[tuple[int, int]] = set()
+    for span in spans:
+        assert 0 <= span.start < span.end <= len(text)
+        key = (span.start, span.end)
+        assert key not in seen
+        seen.add(key)

--- a/tests/test_pseudonym_generator_stubs.py
+++ b/tests/test_pseudonym_generator_stubs.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from __future__ import annotations
 
 import re
 
@@ -55,4 +54,3 @@ def test_import_export() -> None:
     from redactor.pseudo import PseudonymGenerator as Exported
 
     assert Exported is PseudonymGenerator
-


### PR DESCRIPTION
## Summary
- implement RFC5322-inspired email detector with boundary-aware regex and post-validation
- expose detector from `redactor.detect` and surface rich attributes for matched emails
- cover detector with comprehensive unit tests for positives, negatives, and edge cases

## Testing
- `black --check .`
- `ruff check .`
- `mypy .` *(fails: missing dependency pydantic/typer)*
- `pytest -q` *(fails: ModuleNotFoundError: pydantic/typer)*
- `PYTHONPATH=src pytest tests/test_detect_email.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b34b52eb308325aa5ae38876745e9f