### PR TITLE
feat(detect): add account ID validators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "PyYAML>=6",
     "typer>=0.12",
     "phonenumbers>=8.13.0",
+    "python-stdnum>=1.19",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -58,4 +59,8 @@ warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
 module = ["phonenumbers", "phonenumbers.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["stdnum", "stdnum.*"]
 ignore_missing_imports = true

--- a/src/redactor/detect/__init__.py
+++ b/src/redactor/detect/__init__.py
@@ -1,6 +1,7 @@
 """Entity detection components for identifying sensitive information."""
 
+from .account_ids import AccountIdDetector
 from .email import EmailDetector
 from .phone import PhoneDetector
 
-__all__ = ["EmailDetector", "PhoneDetector"]
+__all__ = ["AccountIdDetector", "EmailDetector", "PhoneDetector"]

--- a/tests/test_detect_account_ids.py
+++ b/tests/test_detect_account_ids.py
@@ -1,0 +1,125 @@
+import pytest
+
+from redactor.detect.account_ids import AccountIdDetector
+from redactor.detect.base import EntityLabel, EntitySpan
+
+
+@pytest.fixture
+def det() -> AccountIdDetector:
+    return AccountIdDetector()
+
+
+def _find_span(spans: list[EntitySpan], subtype: str) -> EntitySpan:
+    for s in spans:
+        if s.attrs.get("subtype") == subtype:
+            return s
+    raise AssertionError(f"no span with subtype {subtype}")
+
+
+def test_true_positive_iban(det: AccountIdDetector) -> None:
+    text = "IBAN: GB82 WEST 1234 5698 7654 32."
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.text == "GB82 WEST 1234 5698 7654 32"
+    assert span.start == text.index("GB82 WEST 1234 5698 7654 32")
+    assert span.attrs["subtype"] == "iban"
+    assert span.attrs["normalized"] == "GB82WEST12345698765432"
+    assert span.attrs["issuer_or_country"] == "GB"
+    assert span.label is EntityLabel.ACCOUNT_ID
+
+
+def test_true_positive_bic(det: AccountIdDetector) -> None:
+    text = "SWIFT: DEUTDEFF;"
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.text == "DEUTDEFF"
+    assert span.attrs["subtype"] == "swift_bic"
+    assert span.attrs["issuer_or_country"] == "DE"
+
+
+def test_true_positive_aba_with_context(det: AccountIdDetector) -> None:
+    text = "Routing number (ABA): 021000021, Account: 000123456789."
+    spans = det.detect(text)
+    span = _find_span(spans, "routing_aba")
+    assert span.text == "021000021"
+    assert span.attrs["issuer_or_country"] == "US"
+
+
+def test_true_positive_card(det: AccountIdDetector) -> None:
+    text = "Card: 4111 1111 1111 1111."
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.attrs["subtype"] == "cc"
+    assert span.attrs["scheme"] == "visa"
+    assert span.attrs["normalized"] == "4111111111111111"
+
+
+def test_true_positive_ssn(det: AccountIdDetector) -> None:
+    text = "SSN 123-45-6789"
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.attrs["subtype"] == "ssn"
+    assert span.attrs["display"] == "123-45-6789"
+    assert span.attrs["normalized"] == "123456789"
+
+
+def test_true_positive_ein(det: AccountIdDetector) -> None:
+    text = "Employer EIN: 12-3456789"
+    spans = det.detect(text)
+    span = _find_span(spans, "ein")
+    assert span.attrs["display"] == "12-3456789"
+    assert span.attrs["normalized"] == "123456789"
+
+
+def test_true_positive_generic(det: AccountIdDetector) -> None:
+    text = "Acct # 0034-567-89012"
+    spans = det.detect(text)
+    span = _find_span(spans, "generic")
+    assert span.text == "0034-567-89012"
+    assert span.attrs["normalized"] == "003456789012"
+
+
+def test_boundary_trimming_iban(det: AccountIdDetector) -> None:
+    text = "(GB82WEST12345698765432),"
+    spans = det.detect(text)
+    assert spans and spans[0].text == "GB82WEST12345698765432"
+
+
+def test_boundary_trimming_card(det: AccountIdDetector) -> None:
+    text = "Card: 4111111111111111)."
+    spans = det.detect(text)
+    assert spans and spans[0].text == "4111111111111111"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "2021-03-04",
+        "1,234.56",
+        "03/04/2021",
+        "§ 123.45(a)(2)",
+        "Ref: 000000000",
+        "user@example.com",
+        "021000021",
+    ],
+)
+def test_negatives(det: AccountIdDetector, text: str) -> None:
+    assert det.detect(text) == []
+
+
+def test_overlap_keeps_iban(det: AccountIdDetector) -> None:
+    text = "IBAN: GB82 WEST 1234 5698 7654 32"
+    spans = det.detect(text)
+    assert len(spans) == 1
+    assert spans[0].attrs["subtype"] == "iban"
+
+
+def test_duplicate_card_numbers(det: AccountIdDetector) -> None:
+    text = "4111111111111111 4111111111111111"
+    spans = det.detect(text)
+    assert len(spans) == 2
+    assert spans[0].start != spans[1].start


### PR DESCRIPTION
## Summary
- add AccountIdDetector for IBAN, SWIFT/BIC, ABA routing, card numbers, SSN, EIN and generic account strings
- expose detector in package exports
- depend on python-stdnum and configure mypy overrides
- add tests for account id detection

## Testing
- `ruff check src/redactor/detect/account_ids.py` (pass)
- `black --check .` (pass)
- `mypy .` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'stdnum')*


------
https://chatgpt.com/codex/tasks/task_e_68b3512ab82c8325bde2aee32027a282