### PR TITLE
feat: add BANK_ORG detector

### DIFF
--- a/src/redactor/detect/__init__.py
+++ b/src/redactor/detect/__init__.py
@@ -1,7 +1,13 @@
 """Entity detection components for identifying sensitive information."""
 
 from .account_ids import AccountIdDetector
+from .bank_org import BankOrgDetector
 from .email import EmailDetector
 from .phone import PhoneDetector
 
-__all__ = ["AccountIdDetector", "EmailDetector", "PhoneDetector"]
+__all__ = [
+    "AccountIdDetector",
+    "BankOrgDetector",
+    "EmailDetector",
+    "PhoneDetector",
+]

--- a/src/redactor/detect/bank_org.py
+++ b/src/redactor/detect/bank_org.py
@@ -1,22 +1,299 @@
-"""Bank organization detector.
+"""High‑precision detector for bank and financial organisation names.
 
-Purpose:
-    Recognize names of financial institutions.
+This module implements :class:`BankOrgDetector` which targets explicit
+financial institution phrases such as "Credit Union", "Trust Company",
+"Bank & Trust", and corporate suffixes like "Bank, N.A.".  The detector
+favours high precision:  it relies on conservative regular expressions that
+expect capitalised tokens and well known business suffixes.  Generic phrases
+such as "food bank" or "bank account" are excluded by rule.  After a raw
+match is found the detector trims trailing punctuation on the right but keeps
+leading punctuation (e.g. "(Bank of Foo)" → "Bank of Foo").
 
-Key responsibilities:
-    - Use curated lists or NER models to identify bank names.
-    - Emit spans labeled as `BANK_ORG`.
-
-Inputs/Outputs:
-    - Inputs: text string.
-    - Outputs: list of `EntitySpan` for bank organizations.
-
-Public contracts (planned):
-    - `detect(text)`: Return spans for bank names.
-
-Notes/Edge cases:
-    - Ambiguous abbreviations require context-aware handling.
-
-Dependencies:
-    - Optional external datasets or NER libraries.
+Overlapping spans are resolved by keeping the longest match; when equal in
+length higher confidence wins, and remaining ties are broken by detector
+kind (``credit_union`` ≻ ``trust_company`` ≻ ``bank_and_trust`` ≻
+``bank_of`` ≻ ``token_bank_suffix`` ≻ ``bank``).  NER based augmentation for
+financial institutions without an explicit keyword (e.g. "Morgan Stanley")
+may be added in a future iteration.
 """
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from .base import DetectionContext, EntityLabel, EntitySpan
+
+__all__ = ["BankOrgDetector", "get_detector"]
+
+# ---------------------------------------------------------------------------
+# Patterns and constants
+# ---------------------------------------------------------------------------
+
+TRAILING_PUNCTUATION = ")]};:,.!?»”’>"
+
+_EXCLUDED_PRECEDING = {"Food", "Blood", "Sperm", "Milk", "Energy", "Data"}
+_AFTER_BANK_KEYWORDS = {"account", "accounts", "holiday"}
+
+_SUFFIX_PART = r"N\.??\s?A\.??|National\s+Association|PLC|plc|N\.??\s?V\.??|LLC|Ltd\.??|Limited|USA"
+
+_RX_CREDIT_UNION = re.compile(
+    r"""
+    \b([A-Z][\w&.'-]*(?:\s+[A-Z][\w&.'-]*)*)\s+Credit\s+Union\b
+    """,
+    re.VERBOSE,
+)
+
+_RX_TRUST_COMPANY = re.compile(
+    r"""
+    \b([A-Z][\w&.'-]*(?:\s+[A-Z][\w&.'-]*)*)\s+Trust\s+Company\b
+    """,
+    re.VERBOSE,
+)
+
+_RX_BANK_AND_TRUST = re.compile(
+    r"""
+    \b([A-Z][\w&.'-]*(?:\s+[A-Z][\w&.'-]*)*)\s+
+    (?:Bank\s&\s*Trust|Bank\s+and\s+Trust)(?:\s+Company)?\b
+    """,
+    re.VERBOSE,
+)
+
+# ``Bank of …`` – allows optional tokens before ``Bank`` and an optional
+# corporate suffix following the institution name.
+_RX_BANK_OF = re.compile(
+    rf"""
+    \b(?:[A-Z][\w&.'-]*(?:\s+[A-Z][\w&.'-]*)*\s+)?
+    Bank\s+of\s+[A-Z][\w&.'-]*(?:\s+[A-Z][\w&.'-]*)*
+    (?:\s*(?:,\s*|\s+)(?P<suffix>{_SUFFIX_PART}))?(?=[^\w]|$)
+    """,
+    re.VERBOSE,
+)
+
+# Plain "… Bank" with optional corporate suffix.
+_RX_BANK = re.compile(
+    rf"""
+    \b([A-Z][\w&.'-]*(?:\s+[A-Z][\w&.'-]*)*)\s+Bank
+    (?: (?:,\s*|\s+)(?P<suffix>{_SUFFIX_PART}))?(?=[^\w]|$)
+    """,
+    re.VERBOSE,
+)
+
+# Single token ending with "bank" followed by NA/National Association.
+_RX_TOKEN_BANK_SUFFIX = re.compile(
+    r"""
+    \b([A-Z][A-Za-z0-9&.'-]*bank)\b(?:,\s)?(?P<suffix>N\.??\s?A\.??|National\s+Association)(?=[^\w]|$)
+    """,
+    re.VERBOSE,
+)
+
+_KIND_ORDER = {
+    "credit_union": 0,
+    "trust_company": 1,
+    "bank_and_trust": 2,
+    "bank_of": 3,
+    "token_bank_suffix": 4,
+    "bank": 5,
+}
+
+_HIGH_CONF_SUFFIXES = {"na", "national_association", "plc", "nv"}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_suffix(raw: str | None) -> tuple[str | None, bool]:
+    """Return normalised suffix and ``has_na`` flag."""
+
+    if not raw:
+        return None, False
+    cleaned = raw.lower().replace(".", "").replace(" ", "")
+    if cleaned == "na":
+        return "na", True
+    if cleaned == "nationalassociation":
+        return "national_association", True
+    if cleaned == "plc":
+        return "plc", False
+    if cleaned == "nv":
+        return "nv", False
+    if cleaned == "llc":
+        return "llc", False
+    if cleaned == "ltd":
+        return "ltd", False
+    if cleaned == "limited":
+        return "limited", False
+    if cleaned == "usa":
+        return "usa", False
+    return None, False
+
+
+def _is_mostly_lower(text: str) -> bool:
+    """Return ``True`` if ``text`` is entirely or mostly lowercase."""
+
+    if not text:
+        return True
+    if text == text.lower():
+        return True
+    tokens = re.findall(r"[A-Za-z][\w&.'-]*", text)
+    if not tokens:
+        return True
+    title_count = sum(token[0].isupper() for token in tokens)
+    return title_count < len(tokens) / 2
+
+
+def _trim_end(text: str, start: int, end: int) -> int:
+    """Trim trailing punctuation characters from ``text[start:end]``."""
+
+    while end > start and text[end - 1] in TRAILING_PUNCTUATION:
+        end -= 1
+    return end
+
+
+def _preceding_word(full_text: str, start: int, match_text: str) -> str | None:
+    """Return the word immediately preceding ``Bank`` within the match."""
+
+    rel = match_text.find("Bank")
+    if rel == -1:
+        return None
+    prefix = match_text[:rel].rstrip()
+    tokens = prefix.split()
+    return tokens[-1] if tokens else None
+
+
+def _after_bank_contains(full_text: str, bank_end: int) -> bool:
+    """Return ``True`` if keywords appear within two words after ``bank_end``."""
+
+    after = full_text[bank_end:]
+    # Trim leading whitespace and punctuation
+    i = 0
+    while i < len(after) and not after[i].isalnum():
+        i += 1
+    after = after[i:]
+    tokens = re.split(r"\W+", after)
+    tokens = [t for t in tokens if t]
+    for tok in tokens[:2]:
+        if tok.lower() in _AFTER_BANK_KEYWORDS:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Detector implementation
+# ---------------------------------------------------------------------------
+
+
+class BankOrgDetector:
+    """Detect bank or financial organisation names."""
+
+    def name(self) -> str:  # pragma: no cover - trivial
+        return "bank_org"
+
+    def detect(self, text: str, context: DetectionContext | None = None) -> list[EntitySpan]:
+        """Detect bank organisations in ``text``."""
+
+        candidates: list[EntitySpan] = []
+
+        def handle_matches(matches: Iterable[re.Match[str]], kind: str, hint: str) -> None:
+            for m in matches:
+                start, end = m.span()
+                end = _trim_end(text, start, end)
+                span_text = text[start:end]
+                suffix_raw = m.groupdict().get("suffix")
+
+                # Exclusion heuristics for patterns containing the word "Bank".
+                if "Bank" in span_text:
+                    prev = _preceding_word(text, start, span_text)
+                    if prev in _EXCLUDED_PRECEDING:
+                        continue
+                    bank_idx = span_text.index("Bank")
+                    bank_end = start + bank_idx + len("Bank")
+                    if _after_bank_contains(text, bank_end):
+                        continue
+
+                if _is_mostly_lower(span_text):
+                    continue
+
+                suffix, has_na = _normalize_suffix(suffix_raw)
+                normalized = " ".join(span_text.split()).lower()
+
+                if kind in {"credit_union", "trust_company", "bank_and_trust"}:
+                    conf = 0.96
+                elif suffix in _HIGH_CONF_SUFFIXES:
+                    conf = 0.98
+                else:
+                    conf = 0.93
+
+                attrs: dict[str, object] = {
+                    "normalized": normalized,
+                    "kind": kind,
+                    "suffix": suffix,
+                    "has_na": has_na,
+                    "source_hint": hint,
+                }
+
+                candidates.append(
+                    EntitySpan(
+                        start,
+                        end,
+                        span_text,
+                        EntityLabel.BANK_ORG,
+                        "bank_org",
+                        conf,
+                        attrs,
+                    )
+                )
+
+        handle_matches(_RX_CREDIT_UNION.finditer(text), "credit_union", "rx_credit_union")
+        handle_matches(_RX_TRUST_COMPANY.finditer(text), "trust_company", "rx_trust_company")
+        handle_matches(_RX_BANK_AND_TRUST.finditer(text), "bank_and_trust", "rx_bank_and_trust")
+        handle_matches(_RX_BANK_OF.finditer(text), "bank_of", "rx_bank_of")
+        handle_matches(_RX_BANK.finditer(text), "bank", "rx_bank")
+        handle_matches(
+            _RX_TOKEN_BANK_SUFFIX.finditer(text), "token_bank_suffix", "rx_token_bank_suffix"
+        )
+
+        # Resolve overlaps and duplicates
+        candidates.sort(key=lambda s: (s.start, s.end))
+        resolved: list[EntitySpan] = []
+        for span in candidates:
+            if resolved and not (span.start >= resolved[-1].end or span.end <= resolved[-1].start):
+                existing = resolved[-1]
+                replace = False
+                if span.length > existing.length:
+                    replace = True
+                elif span.length == existing.length:
+                    if span.confidence > existing.confidence:
+                        replace = True
+                    elif span.confidence == existing.confidence:
+                        if (
+                            _KIND_ORDER[str(span.attrs["kind"])]
+                            < _KIND_ORDER[str(existing.attrs["kind"])]
+                        ):
+                            replace = True
+                if replace:
+                    resolved[-1] = span
+            elif resolved and span.start == resolved[-1].start and span.end == resolved[-1].end:
+                # Exact duplicate range, prefer higher confidence then kind order
+                existing = resolved[-1]
+                replace = False
+                if span.confidence > existing.confidence:
+                    replace = True
+                elif (
+                    span.confidence == existing.confidence
+                    and _KIND_ORDER[str(span.attrs["kind"])]
+                    < _KIND_ORDER[str(existing.attrs["kind"])]
+                ):
+                    replace = True
+                if replace:
+                    resolved[-1] = span
+            else:
+                resolved.append(span)
+
+        return resolved
+
+
+def get_detector() -> BankOrgDetector:
+    """Return a :class:`BankOrgDetector` instance."""
+
+    return BankOrgDetector()

--- a/tests/test_detect_bank_org.py
+++ b/tests/test_detect_bank_org.py
@@ -1,0 +1,112 @@
+import pytest
+
+from redactor.detect.bank_org import BankOrgDetector
+from redactor.detect.base import EntityLabel
+
+
+@pytest.fixture
+def det() -> BankOrgDetector:
+    return BankOrgDetector()
+
+
+def test_true_positive_bank_na(det: BankOrgDetector) -> None:
+    text = "Plaintiff shall pay Chase Bank, N.A. within 30 days."
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.text == "Chase Bank, N.A."
+    assert span.label is EntityLabel.BANK_ORG
+    assert span.attrs["kind"] == "bank"
+    assert span.attrs["suffix"] in {"na", "national_association"}
+    assert span.attrs["has_na"] is True
+    assert span.confidence >= 0.98
+
+
+def test_true_positive_bank_of(det: BankOrgDetector) -> None:
+    text = "Deposit is held at Bank of Example, N.A., for escrow."
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.text == "Bank of Example, N.A."
+    assert span.attrs["kind"] == "bank_of"
+    assert span.attrs["suffix"] == "na"
+    assert span.attrs["normalized"] == "bank of example, n.a."
+
+
+def test_true_positive_credit_union(det: BankOrgDetector) -> None:
+    text = "Account at Acme Credit Union will be used."
+    spans = det.detect(text)
+    assert spans and spans[0].text == "Acme Credit Union"
+    assert spans[0].attrs["kind"] == "credit_union"
+    assert spans[0].attrs["suffix"] is None
+
+
+def test_true_positive_trust_company(det: BankOrgDetector) -> None:
+    text = "Trustee: Example Trust Company"
+    spans = det.detect(text)
+    assert spans and spans[0].text == "Example Trust Company"
+    assert spans[0].attrs["kind"] == "trust_company"
+
+
+def test_true_positive_bank_plc(det: BankOrgDetector) -> None:
+    text = "Escrow with Standard Chartered Bank PLC shall apply."
+    spans = det.detect(text)
+    assert spans and spans[0].text == "Standard Chartered Bank PLC"
+    assert spans[0].attrs["kind"] == "bank"
+    assert spans[0].attrs["suffix"] == "plc"
+
+
+def test_true_positive_token_suffix(det: BankOrgDetector) -> None:
+    text = "Citibank, N.A. agrees to…"
+    spans = det.detect(text)
+    assert spans and spans[0].text == "Citibank, N.A."
+    assert spans[0].attrs["kind"] == "token_bank_suffix"
+    assert spans[0].attrs["suffix"] == "na"
+
+
+def test_true_positive_bank_and_trust(det: BankOrgDetector) -> None:
+    text = "State Street Bank & Trust Company will serve as custodian."
+    spans = det.detect(text)
+    assert spans and spans[0].text == "State Street Bank & Trust Company"
+    assert spans[0].attrs["kind"] == "bank_and_trust"
+
+
+def test_trimming_parentheses(det: BankOrgDetector) -> None:
+    text = "(Bank of Anywhere, N.A.),"
+    spans = det.detect(text)
+    assert spans and spans[0].text == "Bank of Anywhere, N.A."
+
+
+def test_trimming_quotes(det: BankOrgDetector) -> None:
+    text = '"Acme Credit Union".'
+    spans = det.detect(text)
+    assert spans and spans[0].text == "Acme Credit Union"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "The food bank distributed meals.",
+        "The Food Bank distributed meals.",
+        "Please provide your bank account number.",
+        "Bank holiday is on Monday.",
+        "the bank shall notify…",
+    ],
+)
+def test_negatives(det: BankOrgDetector, text: str) -> None:
+    assert det.detect(text) == []
+
+
+def test_offsets_and_multiples(det: BankOrgDetector) -> None:
+    text = "Held at Wells Fargo Bank, N.A.; and at Acme Credit Union."
+    spans = det.detect(text)
+    assert len(spans) == 2
+    first, second = spans
+    assert first.text == "Wells Fargo Bank, N.A."
+    assert second.text == "Acme Credit Union"
+    first_start = text.index("Wells Fargo Bank, N.A.")
+    second_start = text.index("Acme Credit Union")
+    assert first.start == first_start
+    assert first.end == first_start + len("Wells Fargo Bank, N.A.")
+    assert second.start == second_start
+    assert second.end == second_start + len("Acme Credit Union")


### PR DESCRIPTION
## Summary
- add BankOrgDetector with regex patterns for banks, credit unions and trust companies
- export detector and add tests

## Testing
- `python -m black --check .`
- `ruff check .`
- `mypy .` (fails: Cannot find implementation or library stub for module named "typer" and others)
- `pytest -q` (fails: ModuleNotFoundError: No module named 'stdnum')

------
https://chatgpt.com/codex/tasks/task_e_68b352cf503083259b654180af913418