### PR TITLE
feat(preprocess): merge address lines into multi-line ADDRESS_BLOCKs with layout awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ text.  Generated names adapt to match initials patterns and interior
 punctuation, keeping the redacted output natural.  For example, a source token
 like ``O’NEIL`` would become ``D’ANGELO`` when replaced.
 
-## Addresses (line-level)
+## Addresses
 
 Street, unit, city/state/ZIP and PO Box lines are detected using the
-``usaddress`` library.  Each line is reported individually with minimal spans
-and structured components.  Adjacent lines will be merged into multi-line
-address blocks in a future milestone.
+``usaddress`` library.  Adjacent lines are merged into a single multi-line
+address block so redaction replaces the entire address at once.  The merger is
+layout-aware and tolerates a single blank line between components.
 
 ## Quick start (CLI)
 

--- a/src/redactor/preprocess/layout_reconstructor.py
+++ b/src/redactor/preprocess/layout_reconstructor.py
@@ -1,22 +1,199 @@
-"""Layout reconstruction utilities.
+"""Layout-aware address block reconstruction.
 
-Purpose:
-    Rebuild document structure from segmented text to support block-level redaction.
-
-Key responsibilities:
-    - Group related lines into blocks such as addresses or party sections.
-    - Track original character offsets for precise replacement.
-
-Inputs/Outputs:
-    - Inputs: sequence of text segments with offsets.
-    - Outputs: structured blocks with span information.
-
-Public contracts (planned):
-    - `reconstruct(segments)`: Yield blocks representing logical layout units.
-
-Notes/Edge cases:
-    - Full-block replacement is used to prevent partial leakage of sensitive data.
-
-Dependencies:
-    - Standard library only.
+This module provides helpers to reason about physical line layout in a piece
+of text and a merger that combines consecutive address line detections into a
+single multi-line ``ADDRESS_BLOCK`` span.  Adjacent address lines are merged
+when they appear on subsequent lines or are separated by exactly one blank
+line.  A ``unit`` line may also precede a ``street`` line and still be merged
+into the same block.  Trailing end-of-line characters are excluded from merged
+spans so that redaction replaces only visible characters.
 """
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, cast
+
+from redactor.detect.base import EntityLabel, EntitySpan
+
+LineIndex = tuple[tuple[int, int, str], ...]
+
+
+def build_line_index(text: str) -> LineIndex:
+    """Return start/end offsets for each line in ``text``.
+
+    Each entry contains ``(line_start, line_end_no_eol, eol_str)``.  The end
+    offset excludes any trailing line ending characters.  ``eol_str`` is ``""``
+    when the line does not terminate with a newline sequence.
+    """
+
+    lines: list[tuple[int, int, str]] = []
+    i = 0
+    length = len(text)
+    while i < length:
+        line_start = i
+        while i < length and text[i] not in "\n\r":
+            i += 1
+        line_end = i
+        eol = ""
+        if i < length:
+            ch = text[i]
+            if ch == "\r" and i + 1 < length and text[i + 1] == "\n":
+                eol = "\r\n"
+                i += 2
+            else:
+                eol = ch
+                i += 1
+        lines.append((line_start, line_end, eol))
+    return tuple(lines)
+
+
+def find_line_for_char(index: int, line_index: LineIndex) -> int:
+    """Return the 0-based line number containing ``index`` via binary search."""
+
+    lo = 0
+    hi = len(line_index) - 1
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        start, end_no_eol, eol = line_index[mid]
+        end_with_eol = end_no_eol + len(eol)
+        if index < start:
+            hi = mid - 1
+        elif index >= end_with_eol:
+            lo = mid + 1
+        else:
+            return mid
+    raise ValueError("index out of range")
+
+
+@dataclass(slots=True)
+class _LineInfo:
+    span: EntitySpan
+    line_no: int
+    line_kind: str
+
+
+def _merge_block(lines: List[_LineInfo], text: str, line_index: LineIndex) -> EntitySpan:
+    start = min(li.span.start for li in lines)
+    last_line_no = lines[-1].line_no
+    end = line_index[last_line_no][1]
+    block_text = text[start:end]
+
+    backends = {cast(str, li.span.attrs.get("backend", "")) for li in lines}
+    backend = backends.pop() if len(backends) == 1 else "mixed"
+
+    line_kinds = [li.line_kind for li in lines]
+    components = [cast(dict[str, str], li.span.attrs.get("components", {})) for li in lines]
+    normalized_parts = [
+        cast(str, li.span.attrs.get("normalized", "")).strip()
+        for li in lines
+        if cast(str, li.span.attrs.get("normalized", "")).strip()
+    ]
+    normalized_block = ", ".join(normalized_parts)
+
+    confidence = min(0.99, max(li.span.confidence for li in lines) + 0.01)
+
+    attrs = {
+        "backend": backend,
+        "lines_count": len(lines),
+        "line_kinds": line_kinds,
+        "components": components,
+        "normalized_block": normalized_block,
+        "has_unit": any(k == "unit" for k in line_kinds),
+        "has_city_state_zip": any(k == "city_state_zip" for k in line_kinds),
+        "merged_from": [{"start": li.span.start, "end": li.span.end} for li in lines],
+    }
+
+    return EntitySpan(
+        start,
+        end,
+        block_text,
+        EntityLabel.ADDRESS_BLOCK,
+        "address_block_merge",
+        confidence,
+        attrs,
+    )
+
+
+def merge_address_lines_into_blocks(text: str, spans: list[EntitySpan]) -> list[EntitySpan]:
+    """Merge adjacent address line spans into multi-line blocks.
+
+    Non-address spans are returned unchanged.  The function tolerates a single
+    blank line between address components and excludes trailing newline
+    characters from the resulting block spans.
+    """
+
+    line_index = build_line_index(text)
+    address_lines: list[_LineInfo] = []
+    others: list[EntitySpan] = []
+
+    for span in spans:
+        if span.label is EntityLabel.ADDRESS_BLOCK and span.source == "address_line":
+            line_kind = cast(str, span.attrs.get("line_kind", ""))
+            line_no = find_line_for_char(span.start, line_index)
+            address_lines.append(_LineInfo(span, line_no, line_kind))
+        else:
+            others.append(span)
+
+    address_lines.sort(key=lambda li: (li.line_no, li.span.start))
+
+    merged: list[EntitySpan] = []
+    i = 0
+    n = len(address_lines)
+    while i < n:
+        current = address_lines[i]
+        block_lines: list[_LineInfo] = [current]
+        j = i + 1
+
+        if (
+            current.line_kind == "unit"
+            and j < n
+            and address_lines[j].line_no == current.line_no + 1
+            and address_lines[j].line_kind == "street"
+        ):
+            block_lines.append(address_lines[j])
+            j += 1
+
+        while j < n:
+            next_line = address_lines[j]
+            prev_line = block_lines[-1]
+            gap = next_line.line_no - prev_line.line_no
+            if gap == 0:
+                if next_line.line_kind in {"unit", "city_state_zip", "street"}:
+                    block_lines.append(next_line)
+                    j += 1
+                else:
+                    break
+            elif gap == 1:
+                if next_line.line_kind in {"unit", "city_state_zip"}:
+                    block_lines.append(next_line)
+                    j += 1
+                else:
+                    break
+            elif gap == 2:
+                idx = prev_line.line_no + 1
+                if (
+                    idx < len(line_index)
+                    and line_index[idx][0] == line_index[idx][1]
+                    and next_line.line_kind in {"unit", "city_state_zip"}
+                ):
+                    block_lines.append(next_line)
+                    j += 1
+                else:
+                    break
+            else:
+                break
+
+        merged.append(_merge_block(block_lines, text, line_index))
+        i = j
+
+    result = others + merged
+    result.sort(key=lambda s: s.start)
+    return result
+
+
+__all__ = [
+    "build_line_index",
+    "find_line_for_char",
+    "merge_address_lines_into_blocks",
+]

--- a/tests/test_address_block_merger.py
+++ b/tests/test_address_block_merger.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import cast
+
+from redactor.detect.base import EntityLabel, EntitySpan
+from redactor.preprocess.layout_reconstructor import merge_address_lines_into_blocks
+
+
+def _make_span(
+    text: str,
+    start: int,
+    end: int,
+    line_kind: str,
+    backend: str = "usaddress",
+    confidence: float = 0.9,
+) -> EntitySpan:
+    attrs: dict[str, object] = {
+        "backend": backend,
+        "line_kind": line_kind,
+        "components": {},
+        "normalized": text[start:end],
+    }
+    return EntitySpan(
+        start,
+        end,
+        text[start:end],
+        EntityLabel.ADDRESS_BLOCK,
+        "address_line",
+        confidence,
+        attrs,
+    )
+
+
+def test_two_line_address() -> None:
+    line1 = "366 Broadway"
+    line2 = "San Francisco, CA 94105"
+    text = f"{line1}\n{line2}\n"
+    span1 = _make_span(text, 0, len(line1), "street")
+    span2 = _make_span(text, len(line1) + 1, len(line1) + 1 + len(line2), "city_state_zip")
+    merged = merge_address_lines_into_blocks(text, [span1, span2])
+    assert len(merged) == 1
+    block = merged[0]
+    assert block.start == 0
+    assert block.end == len(text) - 1  # exclude final newline
+    assert block.text == f"{line1}\n{line2}"
+    assert cast(int, block.attrs["lines_count"]) == 2
+    assert cast(bool, block.attrs["has_city_state_zip"]) is True
+    assert cast(list[str], block.attrs["line_kinds"]) == ["street", "city_state_zip"]
+
+
+def test_three_line_with_unit() -> None:
+    line1 = "366 Broadway"
+    line2 = "Suite 210"
+    line3 = "San Francisco, CA 94105"
+    text = f"{line1}\n{line2}\n{line3}"
+    span1 = _make_span(text, 0, len(line1), "street")
+    span2 = _make_span(text, len(line1) + 1, len(line1) + 1 + len(line2), "unit")
+    span3 = _make_span(text, len(line1) + len(line2) + 2, len(text), "city_state_zip")
+    merged = merge_address_lines_into_blocks(text, [span1, span2, span3])
+    assert len(merged) == 1
+    block = merged[0]
+    assert block.start == 0
+    assert block.end == len(text)
+    assert cast(int, block.attrs["lines_count"]) == 3
+    assert cast(list[str], block.attrs["line_kinds"]) == [
+        "street",
+        "unit",
+        "city_state_zip",
+    ]
+    assert cast(bool, block.attrs["has_unit"]) is True
+
+
+def test_allow_blank_line() -> None:
+    line1 = "366 Broadway"
+    blank = ""
+    line3 = "San Francisco, CA 94105"
+    text = f"{line1}\n{blank}\n{line3}"
+    span1 = _make_span(text, 0, len(line1), "street")
+    span3 = _make_span(text, len(line1) + 2, len(text), "city_state_zip")
+    merged = merge_address_lines_into_blocks(text, [span1, span3])
+    assert len(merged) == 1
+    block = merged[0]
+    assert block.text == text
+    assert cast(int, block.attrs["lines_count"]) == 2
+
+
+def test_unit_preceding_street() -> None:
+    line1 = "Apt 5B"
+    line2 = "123 Main St"
+    line3 = "Springfield, IL 62704"
+    text = f"{line1}\n{line2}\n{line3}"
+    span1 = _make_span(text, 0, len(line1), "unit")
+    span2 = _make_span(text, len(line1) + 1, len(line1) + 1 + len(line2), "street")
+    span3 = _make_span(text, len(line1) + len(line2) + 2, len(text), "city_state_zip")
+    merged = merge_address_lines_into_blocks(text, [span1, span2, span3])
+    assert len(merged) == 1
+    block = merged[0]
+    assert block.start == 0
+    assert block.end == len(text)
+    assert cast(int, block.attrs["lines_count"]) == 3
+
+
+def test_single_line_address_returns_block() -> None:
+    text = "366 Broadway"
+    span = _make_span(text, 0, len(text), "street")
+    merged = merge_address_lines_into_blocks(text, [span])
+    assert len(merged) == 1
+    block = merged[0]
+    assert block.start == 0 and block.end == len(text)
+    assert cast(int, block.attrs["lines_count"]) == 1
+
+
+def test_two_addresses_separated_by_non_address_line() -> None:
+    a1_line1 = "366 Broadway"
+    a1_line2 = "San Francisco, CA 94105"
+    middle = "Contact"
+    a2_line1 = "123 Main St"
+    a2_line2 = "Springfield, IL 62704"
+    text = f"{a1_line1}\n{a1_line2}\n{middle}\n{a2_line1}\n{a2_line2}"
+    a1_span1 = _make_span(text, 0, len(a1_line1), "street")
+    a1_start2 = len(a1_line1) + 1
+    a1_end2 = a1_start2 + len(a1_line2)
+    a1_span2 = _make_span(text, a1_start2, a1_end2, "city_state_zip")
+    a2_start1 = len(a1_line1) + len(a1_line2) + len(middle) + 3
+    a2_span1 = _make_span(text, a2_start1, a2_start1 + len(a2_line1), "street")
+    a2_span2 = _make_span(text, a2_start1 + len(a2_line1) + 1, len(text), "city_state_zip")
+    spans = [a1_span1, a1_span2, a2_span1, a2_span2]
+    merged = merge_address_lines_into_blocks(text, spans)
+    assert len(merged) == 2
+    assert cast(int, merged[0].attrs["lines_count"]) == 2
+    assert cast(int, merged[1].attrs["lines_count"]) == 2
+
+
+def test_pass_through_non_address_span() -> None:
+    line1 = "366 Broadway"
+    line2 = "San Francisco, CA 94105"
+    email = "info@example.com"
+    text = f"{line1}\n{line2}\n{email}"
+    street = _make_span(text, 0, len(line1), "street")
+    city = _make_span(text, len(line1) + 1, len(line1) + 1 + len(line2), "city_state_zip")
+    email_span = EntitySpan(
+        len(line1) + len(line2) + 2,
+        len(text),
+        email,
+        EntityLabel.EMAIL,
+        "email",
+        0.8,
+    )
+    merged = merge_address_lines_into_blocks(text, [street, city, email_span])
+    assert len(merged) == 2
+    assert merged[1] == email_span


### PR DESCRIPTION
## Summary
- add utilities to compute line indices and find line numbers
- merge adjacent address lines into multi-line `ADDRESS_BLOCK` spans with layout-aware rules
- document multi-line address merging in README

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'stdnum')*
- `pip install python-stdnum typer` *(fails: Could not find a version that satisfies the requirement python-stdnum)*

------
https://chatgpt.com/codex/tasks/task_e_68b357a971a483259968ace3d9873bde