### PR TITLE
feat(detect): add generic date detector and contextual DOB classifier with normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Street, unit, city/state/ZIP and PO Box lines are detected using the
 address block so redaction replaces the entire address at once.  The merger is
 layout-aware and tolerates a single blank line between components.
 
+## Dates vs DOBs
+
+The redactor differentiates between general dates and dates of birth.  Dates in
+contracts or correspondence are labelled ``DATE_GENERIC`` and preserved so they
+remain visible in the redacted text.  A date is upgraded to ``DOB`` only when
+nearby lexical triggers such as "DOB", "Date of Birth" or "born" make the
+birthdate intent clear.
+
 ## Quick start (CLI)
 
 ```bash

--- a/src/redactor/detect/__init__.py
+++ b/src/redactor/detect/__init__.py
@@ -3,6 +3,8 @@
 from .account_ids import AccountIdDetector
 from .address_libpostal import AddressLineDetector
 from .bank_org import BankOrgDetector
+from .date_dob import DOBDetector
+from .date_generic import DateGenericDetector
 from .email import EmailDetector
 from .phone import PhoneDetector
 
@@ -12,4 +14,6 @@ __all__ = [
     "AddressLineDetector",
     "EmailDetector",
     "PhoneDetector",
+    "DateGenericDetector",
+    "DOBDetector",
 ]

--- a/src/redactor/detect/date_dob.py
+++ b/src/redactor/detect/date_dob.py
@@ -1,22 +1,134 @@
-"""Date-of-birth detector.
+"""Contextual date-of-birth detector.
 
-Purpose:
-    Identify dates that likely correspond to a person's birthdate.
+This detector promotes generic date spans to :class:`~redactor.detect.base.EntityLabel.DOB`
+when explicit lexical cues suggest the date refers to a person's birth.  It
+reuses :class:`DateGenericDetector` to obtain candidate dates and then searches
+for triggers such as ``DOB``, ``Date of Birth`` or ``born`` on the same line or
+immediately preceding line.  Only dates that normalise successfully to
+``YYYY-MM-DD`` are eligible.
 
-Key responsibilities:
-    - Use contextual cues around generic dates to infer DOB.
-    - Emit spans labeled as `DATE_DOB`.
-
-Inputs/Outputs:
-    - Inputs: text string.
-    - Outputs: list of `EntitySpan` for DOB mentions.
-
-Public contracts (planned):
-    - `detect(text)`: Return spans for probable birth dates.
-
-Notes/Edge cases:
-    - Age references ("born on") improve precision.
-
-Dependencies:
-    - Relies on `date_generic` detector output.
+Confidence is ``0.99`` for explicit ``DOB``/``Date of Birth``/``birthdate``
+triggers and ``0.98`` when relying solely on ``born``.  The resulting span
+shares the exact boundaries of the underlying date and carries through the
+``normalized`` and ``components`` attributes from the generic detector while
+adding ``trigger`` and ``line_scope`` metadata.
 """
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Tuple, cast
+
+from redactor.preprocess.layout_reconstructor import (
+    LineIndex,
+    build_line_index,
+    find_line_for_char,
+)
+
+from .base import DetectionContext, EntityLabel, EntitySpan
+from .date_generic import DateGenericDetector
+
+__all__ = ["DOBDetector", "get_detector"]
+
+# ---------------------------------------------------------------------------
+# Trigger patterns
+# ---------------------------------------------------------------------------
+
+_DOB_PATTERNS: List[Tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bD(?:\.\s*O\.\s*B|OB)\b", re.IGNORECASE), "dob"),
+    (re.compile(r"\bdate\s+of\s+birth\b", re.IGNORECASE), "date_of_birth"),
+    (re.compile(r"\bbirth\s*date\b|\bbirthdate\b", re.IGNORECASE), "birthdate"),
+]
+
+_BORN_PATTERN = re.compile(r"\bborn\b", re.IGNORECASE)
+
+_WINDOW_CHARS = 40
+
+# ---------------------------------------------------------------------------
+# Detector implementation
+# ---------------------------------------------------------------------------
+
+
+class DOBDetector:
+    """Classify dates of birth based on context."""
+
+    _confidence_explicit: float = 0.99
+    _confidence_born: float = 0.98
+
+    def __init__(self) -> None:
+        self._date_detector = DateGenericDetector()
+
+    def name(self) -> str:  # pragma: no cover - trivial
+        return "date_dob"
+
+    def detect(self, text: str, context: DetectionContext | None = None) -> list[EntitySpan]:
+        """Detect DOB mentions in ``text``."""
+
+        _ = context
+        candidates = self._date_detector.detect(text, context)
+        line_index: LineIndex = build_line_index(text)
+        spans: list[EntitySpan] = []
+
+        for span in candidates:
+            normalized = cast(str | None, span.attrs.get("normalized"))
+            if not normalized:
+                continue
+            components = cast(dict[str, str] | None, span.attrs.get("components"))
+            line_no = find_line_for_char(span.start, line_index)
+            line_start, _, _ = line_index[line_no]
+            window_start = max(line_start, span.start - _WINDOW_CHARS)
+            left_context = text[window_start : span.start]
+            trigger: str | None = None
+            line_scope = "same_line"
+
+            for pattern, name in _DOB_PATTERNS:
+                if pattern.search(left_context):
+                    trigger = name
+                    break
+
+            if not trigger and _BORN_PATTERN.search(left_context):
+                trigger = "born"
+
+            if not trigger and line_no > 0:
+                prev_start, prev_end, _ = line_index[line_no - 1]
+                prev_text = text[prev_start:prev_end]
+                for pattern, name in _DOB_PATTERNS:
+                    if pattern.search(prev_text):
+                        trigger = name
+                        line_scope = "prev_line"
+                        break
+                if not trigger and _BORN_PATTERN.search(prev_text):
+                    trigger = "born"
+                    line_scope = "prev_line"
+
+            if not trigger:
+                continue
+
+            confidence = self._confidence_explicit if trigger != "born" else self._confidence_born
+
+            attrs: Dict[str, object] = {
+                "normalized": normalized,
+                "components": components,
+                "trigger": trigger,
+                "line_scope": line_scope,
+            }
+            spans.append(
+                EntitySpan(
+                    span.start,
+                    span.end,
+                    span.text,
+                    EntityLabel.DOB,
+                    "date_dob",
+                    confidence,
+                    attrs,
+                )
+            )
+
+        spans.sort(key=lambda s: s.start)
+        return spans
+
+
+def get_detector() -> DOBDetector:
+    """Return a :class:`DOBDetector` instance."""
+
+    return DOBDetector()

--- a/src/redactor/detect/date_generic.py
+++ b/src/redactor/detect/date_generic.py
@@ -1,22 +1,235 @@
-"""Generic date detector.
+"""Generic date detector with lightweight normalisation.
 
-Purpose:
-    Find date expressions in various formats.
+This detector focuses on a small set of high‑precision date patterns and
+avoids heavy parsing libraries.  Supported formats (case‑insensitive) are::
 
-Key responsibilities:
-    - Match numeric and textual date representations.
-    - Normalize to a standard format for comparison.
+    Month D, YYYY   e.g. "July 4, 1982" (comma optional)
+    D Month YYYY    e.g. "4 July 1982"
+    YYYY-MM-DD      ISO style with four digit year
+    M/D/YYYY        or ``M-D-YYYY`` with a four digit year (US ordering)
 
-Inputs/Outputs:
-    - Inputs: text string.
-    - Outputs: list of `EntitySpan` for date occurrences.
-
-Public contracts (planned):
-    - `detect(text)`: Return spans for dates.
-
-Notes/Edge cases:
-    - Ambiguous formats (e.g., 01/02/03) require locale awareness.
-
-Dependencies:
-    - `dateutil` (optional).
+Normalisation is best‑effort and yields a ``YYYY-MM-DD`` string when the
+components form a valid Gregorian date.  The numeric format assumes the
+first number is the month (US default).  Invalid combinations still emit a
+``DATE_GENERIC`` span but with ``normalized`` set to ``None``.
 """
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Tuple
+
+from .base import DetectionContext, EntityLabel, EntitySpan
+
+__all__ = ["DateGenericDetector", "get_detector"]
+
+# ---------------------------------------------------------------------------
+# Helpers and regular expressions
+# ---------------------------------------------------------------------------
+
+TRAILING_PUNCTUATION = ")]};:,.!?»”’>"
+
+_MONTHS: Dict[str, str] = {
+    "january": "01",
+    "jan": "01",
+    "february": "02",
+    "feb": "02",
+    "march": "03",
+    "mar": "03",
+    "april": "04",
+    "apr": "04",
+    "may": "05",
+    "june": "06",
+    "jun": "06",
+    "july": "07",
+    "jul": "07",
+    "august": "08",
+    "aug": "08",
+    "september": "09",
+    "sep": "09",
+    "sept": "09",
+    "october": "10",
+    "oct": "10",
+    "november": "11",
+    "nov": "11",
+    "december": "12",
+    "dec": "12",
+}
+
+_MONTH_NAME_PATTERN = "|".join(sorted(_MONTHS.keys(), key=len, reverse=True))
+
+_MONTH_NAME_MDY_RE = re.compile(
+    rf"\b({_MONTH_NAME_PATTERN})\s+(\d{{1,2}}(?:st|nd|rd|th)?),?\s+(\d{{4}})\b",
+    re.IGNORECASE,
+)
+
+_MONTH_NAME_DMY_RE = re.compile(
+    rf"\b(\d{{1,2}}(?:st|nd|rd|th)?)\s+({_MONTH_NAME_PATTERN})\s+(\d{{4}})\b",
+    re.IGNORECASE,
+)
+
+_ISO_RE = re.compile(r"\b(\d{4})-(\d{2})-(\d{2})\b")
+
+_NUMERIC_RE = re.compile(r"\b(\d{1,2})[/-](\d{1,2})[/-](\d{4})\b")
+
+
+def _is_leap(year: int) -> bool:
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+
+
+def _days_in_month(year: int, month: int) -> int:
+    if month in {1, 3, 5, 7, 8, 10, 12}:
+        return 31
+    if month in {4, 6, 9, 11}:
+        return 30
+    if month == 2:
+        return 29 if _is_leap(year) else 28
+    return 0
+
+
+def _normalize(year: str, month: str, day: str) -> Tuple[str | None, Dict[str, str] | None]:
+    """Return normalised date and components if valid."""
+
+    try:
+        y = int(year)
+        m = int(month)
+        d = int(day)
+    except ValueError:
+        return None, None
+    if not 1 <= m <= 12:
+        return None, None
+    if not 1 <= d <= _days_in_month(y, m):
+        return None, None
+    normalized = f"{y:04d}-{m:02d}-{d:02d}"
+    components = {"year": f"{y:04d}", "month": f"{m:02d}", "day": f"{d:02d}"}
+    return normalized, components
+
+
+# ---------------------------------------------------------------------------
+# Detector implementation
+# ---------------------------------------------------------------------------
+
+
+class DateGenericDetector:
+    """Detect generic dates within text."""
+
+    _confidence_named: float = 0.97
+    _confidence_numeric: float = 0.94
+
+    def name(self) -> str:  # pragma: no cover - trivial
+        return "date_generic"
+
+    def detect(self, text: str, context: DetectionContext | None = None) -> list[EntitySpan]:
+        """Detect dates in ``text``."""
+
+        _ = context
+        spans: list[EntitySpan] = []
+
+        for match in _MONTH_NAME_MDY_RE.finditer(text):
+            month_name, day_raw, year = match.groups()
+            start, end = match.span()
+            date_text = text[start:end]
+            while date_text and date_text[-1] in TRAILING_PUNCTUATION:
+                end -= 1
+                date_text = date_text[:-1]
+            day = re.sub(r"(?i)(st|nd|rd|th)$", "", day_raw)
+            month_num = _MONTHS.get(month_name.lower(), "00")
+            normalized, components = _normalize(year, month_num, day)
+            attrs: Dict[str, object] = {"format": "month_name_mdY", "normalized": normalized}
+            if components:
+                attrs["components"] = components
+            spans.append(
+                EntitySpan(
+                    start,
+                    end,
+                    date_text,
+                    EntityLabel.DATE_GENERIC,
+                    "date_generic",
+                    self._confidence_named,
+                    attrs,
+                )
+            )
+
+        for match in _MONTH_NAME_DMY_RE.finditer(text):
+            day_raw, month_name, year = match.groups()
+            start, end = match.span()
+            date_text = text[start:end]
+            while date_text and date_text[-1] in TRAILING_PUNCTUATION:
+                end -= 1
+                date_text = date_text[:-1]
+            day = re.sub(r"(?i)(st|nd|rd|th)$", "", day_raw)
+            month_num = _MONTHS.get(month_name.lower(), "00")
+            normalized, components = _normalize(year, month_num, day)
+            attrs = {"format": "month_name_dmY", "normalized": normalized}
+            if components:
+                attrs["components"] = components
+            spans.append(
+                EntitySpan(
+                    start,
+                    end,
+                    date_text,
+                    EntityLabel.DATE_GENERIC,
+                    "date_generic",
+                    self._confidence_named,
+                    attrs,
+                )
+            )
+
+        for match in _ISO_RE.finditer(text):
+            year, month, day = match.groups()
+            start, end = match.span()
+            date_text = text[start:end]
+            while date_text and date_text[-1] in TRAILING_PUNCTUATION:
+                end -= 1
+                date_text = date_text[:-1]
+            normalized, components = _normalize(year, month, day)
+            attrs = {"format": "iso", "normalized": normalized}
+            if components:
+                attrs["components"] = components
+            spans.append(
+                EntitySpan(
+                    start,
+                    end,
+                    date_text,
+                    EntityLabel.DATE_GENERIC,
+                    "date_generic",
+                    self._confidence_named,
+                    attrs,
+                )
+            )
+
+        for match in _NUMERIC_RE.finditer(text):
+            month, day, year = match.groups()
+            start, end = match.span()
+            date_text = text[start:end]
+            while date_text and date_text[-1] in TRAILING_PUNCTUATION:
+                end -= 1
+                date_text = date_text[:-1]
+            normalized, components = _normalize(year, month, day)
+            attrs = {"format": "mdY_numeric", "normalized": normalized}
+            if components:
+                attrs["components"] = components
+            spans.append(
+                EntitySpan(
+                    start,
+                    end,
+                    date_text,
+                    EntityLabel.DATE_GENERIC,
+                    "date_generic",
+                    self._confidence_numeric,
+                    attrs,
+                )
+            )
+
+        unique: Dict[Tuple[int, int], EntitySpan] = {}
+        for span in spans:
+            key = (span.start, span.end)
+            if key not in unique:
+                unique[key] = span
+        return sorted(unique.values(), key=lambda s: s.start)
+
+
+def get_detector() -> DateGenericDetector:
+    """Return a :class:`DateGenericDetector` instance."""
+
+    return DateGenericDetector()

--- a/tests/test_detect_dates.py
+++ b/tests/test_detect_dates.py
@@ -1,0 +1,141 @@
+import pytest
+
+from redactor.detect.base import Detector, EntityLabel
+from redactor.detect.date_dob import DOBDetector
+from redactor.detect.date_generic import DateGenericDetector
+
+
+@pytest.fixture
+def det_generic() -> DateGenericDetector:
+    return DateGenericDetector()
+
+
+@pytest.fixture
+def det_dob() -> DOBDetector:
+    return DOBDetector()
+
+
+# ---------------------------------------------------------------------------
+# Positive DOB detections
+# ---------------------------------------------------------------------------
+
+
+def test_dob_date_of_birth(det_generic: DateGenericDetector, det_dob: DOBDetector) -> None:
+    text = "Date of Birth: July 4, 1982"
+    g_spans = det_generic.detect(text)
+    assert g_spans and g_spans[0].attrs["normalized"] == "1982-07-04"
+    spans = det_dob.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.text == "July 4, 1982"
+    expected_start = text.index("July 4, 1982")
+    assert span.start == expected_start
+    assert span.end == expected_start + len("July 4, 1982")
+    assert span.attrs["normalized"] == "1982-07-04"
+    assert span.attrs["trigger"] == "date_of_birth"
+    assert span.attrs["line_scope"] == "same_line"
+    assert span.label is EntityLabel.DOB
+
+
+def test_dob_short_label_numeric(det_dob: DOBDetector) -> None:
+    text = "DOB 12/21/1975"
+    spans = det_dob.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    expected_start = text.index("12/21/1975")
+    assert span.start == expected_start
+    assert span.end == expected_start + len("12/21/1975")
+    assert span.attrs["normalized"] == "1975-12-21"
+    assert span.attrs["trigger"] == "dob"
+
+
+def test_dob_born_trigger(det_dob: DOBDetector) -> None:
+    text = "Born on 4 July 1975"
+    spans = det_dob.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.attrs["normalized"] == "1975-07-04"
+    assert span.attrs["trigger"] == "born"
+
+
+# ---------------------------------------------------------------------------
+# Generic date detections without DOB
+# ---------------------------------------------------------------------------
+
+
+def test_generic_not_dob(det_generic: DateGenericDetector, det_dob: DOBDetector) -> None:
+    text1 = "Executed on July 4, 1982"
+    assert det_generic.detect(text1)
+    assert det_dob.detect(text1) == []
+
+    text2 = "As of 2020-01-31, the agreement…"
+    assert det_generic.detect(text2)
+    assert det_dob.detect(text2) == []
+
+
+# ---------------------------------------------------------------------------
+# Punctuation trimming
+# ---------------------------------------------------------------------------
+
+
+def test_punctuation_trimming(det_generic: DateGenericDetector, det_dob: DOBDetector) -> None:
+    text = "(Date of Birth: July 4, 1982)."
+    g_spans = det_generic.detect(text)
+    assert g_spans and g_spans[0].text == "July 4, 1982"
+    spans = det_dob.detect(text)
+    assert spans and spans[0].text == "July 4, 1982"
+
+
+# ---------------------------------------------------------------------------
+# Multiple dates
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_dates(det_generic: DateGenericDetector, det_dob: DOBDetector) -> None:
+    text = "DOB: 07/04/1982. Executed on 07/05/1982."
+    g_spans = det_generic.detect(text)
+    assert [s.text for s in g_spans] == ["07/04/1982", "07/05/1982"]
+    spans = det_dob.detect(text)
+    assert [s.text for s in spans] == ["07/04/1982"]
+
+
+# ---------------------------------------------------------------------------
+# Edge validation
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_date_not_dob(det_generic: DateGenericDetector, det_dob: DOBDetector) -> None:
+    text = "DOB: February 29, 2021"
+    g_spans = det_generic.detect(text)
+    assert g_spans and g_spans[0].attrs["normalized"] is None
+    assert det_dob.detect(text) == []
+
+
+# ---------------------------------------------------------------------------
+# Line context
+# ---------------------------------------------------------------------------
+
+
+def test_line_context_same_and_prev(det_dob: DOBDetector) -> None:
+    text = "John Doe\nDate of Birth: December 21, 1975\nAddress: ..."
+    spans = det_dob.detect(text)
+    assert spans and spans[0].attrs["line_scope"] == "same_line"
+    assert spans[0].attrs["trigger"] == "date_of_birth"
+
+    text2 = "Date of Birth\nJuly 4, 1982"
+    spans2 = det_dob.detect(text2)
+    assert spans2 and spans2[0].attrs["line_scope"] == "prev_line"
+
+
+# ---------------------------------------------------------------------------
+# Detector protocol integration
+# ---------------------------------------------------------------------------
+
+
+def test_detector_protocol(det_generic: DateGenericDetector, det_dob: DOBDetector) -> None:
+    assert isinstance(det_generic, Detector)
+    assert isinstance(det_dob, Detector)
+    text = "Date of Birth: July 4, 1982"
+    spans = det_dob.detect(text)
+    for span in spans:
+        assert 0 <= span.start < span.end <= len(text)


### PR DESCRIPTION
## Summary
- implement regex-based DateGenericDetector with normalization
- add DOBDetector using contextual triggers
- document date handling and add tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy --strict .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'stdnum')*

------
https://chatgpt.com/codex/tasks/task_e_68b359996eac8325bdb7f9fe828d9610