### PR TITLE
feat(detect): add legal alias detector for hereinafter/AKA/FKA/DBA

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ remain visible in the redacted text.  A date is upgraded to ``DOB`` only when
 nearby lexical triggers such as "DOB", "Date of Birth" or "born" make the
 birthdate intent clear.
 
+## Legal aliases
+
+Alias labels defined with phrases such as ``hereinafter``, ``a/k/a`` (also known
+as), ``f/k/a`` (formerly known as) or ``d/b/a`` (doing business as) are detected
+as ``ALIAS_LABEL`` spans.  Only the alias term itself is captured – for example
+``"Buyer"`` or ``"Morgan"`` – while trigger words and punctuation are ignored.
+When a subject name appears nearby, the detector records it so later stages can
+link all references to a consistent pseudonym.
+
 ## Quick start (CLI)
 
 ```bash

--- a/src/redactor/cli.py
+++ b/src/redactor/cli.py
@@ -32,13 +32,13 @@ app = typer.Typer(
 )
 
 
-@app.callback()  # type: ignore[misc]
+@app.callback()
 def main() -> None:
     """Entry point for the redactor command group."""
     pass
 
 
-@app.command()  # type: ignore[misc]
+@app.command()
 def run(
     in_path: Path = typer.Option(..., "--in", help="Input file (.txt only for now)"),  # noqa: B008
     out_path: Path = typer.Option(..., "--out", help="Output file (.txt)"),  # noqa: B008

--- a/src/redactor/detect/__init__.py
+++ b/src/redactor/detect/__init__.py
@@ -2,6 +2,7 @@
 
 from .account_ids import AccountIdDetector
 from .address_libpostal import AddressLineDetector
+from .aliases import AliasDetector
 from .bank_org import BankOrgDetector
 from .date_dob import DOBDetector
 from .date_generic import DateGenericDetector
@@ -16,4 +17,5 @@ __all__ = [
     "PhoneDetector",
     "DateGenericDetector",
     "DOBDetector",
+    "AliasDetector",
 ]

--- a/src/redactor/detect/aliases.py
+++ b/src/redactor/detect/aliases.py
@@ -1,22 +1,299 @@
-"""Alias detector.
+"""Legal alias detector for "hereinafter" / AKA / FKA / DBA patterns.
 
-Purpose:
-    Discover known aliases or AKA references for entities.
+This module provides :class:`AliasDetector`, a lightweight regular-expression
+based detector that identifies legal alias definitions such as
+``hereinafter "Buyer"`` or ``a/k/a "Johnny"``.  Only the alias label itself is
+returned as a span (the contents inside quotes or the title‑cased token), while
+trigger words and surrounding punctuation are excluded.  When possible the
+detector associates the alias with a nearby subject mention to aid later
+resolution.
 
-Key responsibilities:
-    - Scan for patterns like "aka" or "alias" followed by a name.
-    - Normalize aliases for linking with primary identities.
+The detector emits spans labelled :class:`~redactor.detect.base.EntityLabel`
+``ALIAS_LABEL`` with attributes describing the trigger, quote style, subject
+information and whether the alias is a role label or a nickname.  It performs a
+few conservative sanity checks to avoid false positives and de‑duplicates spans
+with identical boundaries.
 
-Inputs/Outputs:
-    - Inputs: text string.
-    - Outputs: list of `EntitySpan` for alias names.
-
-Public contracts (planned):
-    - `detect(text)`: Return spans for alias mentions.
-
-Notes/Edge cases:
-    - Multiple aliases in a single phrase should produce distinct spans.
-
-Dependencies:
-    - `patterns` module.
+This detector merely reports alias labels; it does not attempt to link them to
+subjects or perform replacements.  Alias resolution is handled in later
+pipeline stages.
 """
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Iterator
+
+from redactor.preprocess.layout_reconstructor import (
+    build_line_index,
+    find_line_for_char,
+)
+
+from .base import DetectionContext, EntityLabel, EntitySpan
+
+__all__ = ["AliasDetector", "get_detector"]
+
+# ---------------------------------------------------------------------------
+# Regular expressions
+# ---------------------------------------------------------------------------
+
+# Basic building blocks -----------------------------------------------------
+NAME_TOKEN = r"[A-Z][\w&.’’-]*"
+NAME_PHRASE = rf"{NAME_TOKEN}(?:\s+{NAME_TOKEN}){{0,6}}"
+
+QUOTE_CHARS = "\"'“”‘’"
+QUOTE_CLASS = re.escape(QUOTE_CHARS)
+TRAILING_PUNCTUATION = ")]};:,.!?»”’>"
+
+ROLE_LABELS: frozenset[str] = frozenset(
+    {
+        "Buyer",
+        "Seller",
+        "Lender",
+        "Borrower",
+        "Landlord",
+        "Tenant",
+        "Guarantor",
+        "Licensor",
+        "Licensee",
+        "Plaintiff",
+        "Defendant",
+        "Petitioner",
+        "Respondent",
+        "Trustee",
+        "Executor",
+        "Administrator",
+        "Assignor",
+        "Assignee",
+        "Discloser",
+        "Recipient",
+    }
+)
+
+
+HEREIN_WITH_SUBJECT_REGEX = re.compile(
+    rf"""
+    (?P<subject>{NAME_PHRASE})\s*,?\s*
+    (?P<trigger>hereinafter|hereafter)\s+
+    (?:referred\s+to\s+as\s+)?
+    (?P<q1>[{QUOTE_CLASS}])(?P<alias>[^{QUOTE_CLASS}]+?)(?P<q2>[{QUOTE_CLASS}])
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+HEREIN_ALIAS_ONLY_REGEX = re.compile(
+    rf"""
+    (?P<trigger>hereinafter|hereafter)\s+
+    (?:referred\s+to\s+as\s+)?
+    (?P<q1>[{QUOTE_CLASS}])(?P<alias>[^{QUOTE_CLASS}]+?)(?P<q2>[{QUOTE_CLASS}])
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+AKA_QUOTED_REGEX = re.compile(
+    rf"""
+    (?P<subject>{NAME_PHRASE})\s*,?\s*
+    (?P<trigger>a/k/a|aka|f/k/a|fka|d/b/a|dba)\s+
+    (?P<q1>[{QUOTE_CLASS}])(?P<alias>[^{QUOTE_CLASS}]+?)(?P<q2>[{QUOTE_CLASS}])
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+AKA_UNQUOTED_REGEX = re.compile(
+    rf"""
+    (?P<subject>{NAME_PHRASE})\s*,?\s*
+    (?P<trigger>a/k/a|aka|f/k/a|fka|d/b/a|dba)\s+
+    (?P<alias>{NAME_PHRASE})(?=[^A-Za-z&.’’-]|$)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _normalize_trigger(value: str) -> str:
+    value = value.lower().replace("/", "")
+    if value in {"aka", "fka", "dba", "hereinafter", "hereafter"}:
+        return value
+    return value
+
+
+def _is_title_token(token: str) -> bool:
+    return bool(re.match(r"^[A-Z][\w&.’’-]*$", token))
+
+
+def _looks_like_subject(text: str) -> bool:
+    if re.search(r"\b(LLC|Inc\.?|Ltd\.?|N\.A\.)\b", text):
+        return True
+    words = text.split()
+    for i in range(len(words) - 1):
+        if _is_title_token(words[i]) and _is_title_token(words[i + 1]):
+            return True
+    return False
+
+
+def _guess_subject(
+    start: int, text: str, line_index: tuple[tuple[int, int, str], ...]
+) -> tuple[str | None, int | None]:
+    try:
+        line_no = find_line_for_char(start, line_index)
+    except ValueError:
+        return None, None
+    looked = 0
+    prev = line_no - 1
+    while prev >= 0 and looked < 2:
+        l_start, l_end, _ = line_index[prev]
+        candidate = text[l_start:l_end].strip()
+        if candidate:
+            looked += 1
+            if _looks_like_subject(candidate):
+                return candidate, prev
+        prev -= 1
+    return None, None
+
+
+def _trim(alias: str, end: int) -> tuple[str, int]:
+    while alias and alias[-1] in TRAILING_PUNCTUATION:
+        alias = alias[:-1]
+        end -= 1
+    return alias, end
+
+
+@dataclass(slots=True)
+class _MatchInfo:
+    alias_start: int
+    alias_end: int
+    trigger: str
+    quote_style: str | None
+    subject_text: str | None
+    subject_span: tuple[int, int] | None
+    subject_guess: str | None
+    subject_guess_line: int | None
+    scope_hint: str
+    confidence: float
+
+
+def _iter_matches(text: str) -> Iterator[_MatchInfo]:
+    line_index = build_line_index(text)
+
+    patterns: Iterable[re.Pattern[str]] = (
+        HEREIN_WITH_SUBJECT_REGEX,
+        AKA_QUOTED_REGEX,
+        AKA_UNQUOTED_REGEX,
+    )
+
+    for pattern in patterns:
+        for m in pattern.finditer(text):
+            alias_start, alias_end = m.span("alias")
+            subject_text = m.groupdict().get("subject")
+            subject_span = m.span("subject") if subject_text else None
+            trigger = _normalize_trigger(m.group("trigger"))
+            q1 = m.groupdict().get("q1")
+            q2 = m.groupdict().get("q2")
+            quote_style = (q1 or "") + (q2 or "") if q1 or q2 else None
+            yield _MatchInfo(
+                alias_start,
+                alias_end,
+                trigger,
+                quote_style,
+                subject_text,
+                subject_span,
+                None,
+                None,
+                "same_line",
+                0.99,
+            )
+
+    for m in HEREIN_ALIAS_ONLY_REGEX.finditer(text):
+        alias_start, alias_end = m.span("alias")
+        trigger = _normalize_trigger(m.group("trigger"))
+        q1 = m.groupdict().get("q1")
+        q2 = m.groupdict().get("q2")
+        quote_style = (q1 or "") + (q2 or "") if q1 or q2 else None
+        subj_guess, subj_line = _guess_subject(alias_start, text, line_index)
+        if subj_guess is not None:
+            confidence = 0.97
+            scope = "prev_lines"
+        else:
+            confidence = 0.95
+            scope = "same_line"
+        yield _MatchInfo(
+            alias_start,
+            alias_end,
+            trigger,
+            quote_style,
+            None,
+            None,
+            subj_guess,
+            subj_line,
+            scope,
+            confidence,
+        )
+
+
+class AliasDetector:
+    """Detect legal alias labels such as AKA or hereinafter definitions."""
+
+    def name(self) -> str:  # pragma: no cover - trivial
+        return "aliases"
+
+    def detect(self, text: str, context: DetectionContext | None = None) -> list[EntitySpan]:
+        _ = context
+        spans: list[EntitySpan] = []
+        for mi in _iter_matches(text):
+            alias_text = text[mi.alias_start : mi.alias_end]
+            alias_text, alias_end = _trim(alias_text, mi.alias_end)
+            if not alias_text:
+                continue
+            if "@" in alias_text:
+                continue
+            tokens = alias_text.split()
+            if len(tokens) > 6 and any(t and t[0].islower() for t in tokens):
+                continue
+            alias_kind = "role" if alias_text in ROLE_LABELS else "nickname"
+            role_flag = alias_kind == "role"
+
+            attrs: dict[str, object] = {
+                "alias": alias_text,
+                "alias_kind": alias_kind,
+                "trigger": mi.trigger,
+                "quote_style": mi.quote_style,
+                "subject_text": mi.subject_text,
+                "subject_span": (
+                    {
+                        "start": mi.subject_span[0],
+                        "end": mi.subject_span[1],
+                    }
+                    if mi.subject_span
+                    else None
+                ),
+                "subject_guess": mi.subject_guess,
+                "subject_guess_line": mi.subject_guess_line,
+                "scope_hint": mi.scope_hint,
+                "confidence": mi.confidence,
+                "role_flag": role_flag,
+            }
+
+            spans.append(
+                EntitySpan(
+                    mi.alias_start,
+                    alias_end,
+                    alias_text,
+                    EntityLabel.ALIAS_LABEL,
+                    "aliases",
+                    mi.confidence,
+                    attrs,
+                )
+            )
+
+        unique: dict[tuple[int, int], EntitySpan] = {}
+        for sp in spans:
+            key = (sp.start, sp.end)
+            if key not in unique:
+                unique[key] = sp
+        return sorted(unique.values(), key=lambda s: s.start)
+
+
+def get_detector() -> AliasDetector:
+    """Return an :class:`AliasDetector` instance."""
+
+    return AliasDetector()

--- a/tests/test_detect_aliases.py
+++ b/tests/test_detect_aliases.py
@@ -1,0 +1,114 @@
+import pytest
+
+from redactor.detect.aliases import AliasDetector
+from redactor.detect.base import Detector, EntityLabel
+
+
+@pytest.fixture
+def det() -> AliasDetector:
+    return AliasDetector()
+
+
+def test_hereinafter_same_line(det: AliasDetector) -> None:
+    text = 'John Doe, hereinafter "Morgan", agrees'
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.text == "Morgan"
+    start = text.index('"Morgan"') + 1
+    assert (span.start, span.end) == (start, start + len("Morgan"))
+    assert span.label is EntityLabel.ALIAS_LABEL
+    attrs = span.attrs
+    assert attrs["alias"] == "Morgan"
+    assert attrs["trigger"] == "hereinafter"
+    assert attrs["subject_text"] == "John Doe"
+    assert attrs["scope_hint"] == "same_line"
+    assert attrs["alias_kind"] == "nickname"
+    assert attrs["role_flag"] is False
+    assert attrs["subject_span"] == {"start": 0, "end": len("John Doe")}
+    assert span.confidence == pytest.approx(0.99)
+
+
+def test_role_alias(det: AliasDetector) -> None:
+    text = 'Acme LLC (hereinafter referred to as "Seller")'
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.text == "Seller"
+    attrs = span.attrs
+    assert attrs["alias_kind"] == "role"
+    assert attrs["role_flag"] is True
+    assert attrs["subject_text"] == "Acme LLC"
+    assert attrs["trigger"] == "hereinafter"
+
+
+def test_hereinafter_prev_line_guess(det: AliasDetector) -> None:
+    text = 'John Doe\nHereinafter "Morgan" signs'
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    attrs = span.attrs
+    assert attrs["subject_text"] is None
+    assert attrs["subject_guess"] == "John Doe"
+    assert attrs["subject_guess_line"] == 0
+    assert attrs["scope_hint"] == "prev_lines"
+    assert span.confidence == pytest.approx(0.97)
+
+
+def test_aka(det: AliasDetector) -> None:
+    text = 'Jane Smith, a/k/a "Janie"'
+    spans = det.detect(text)
+    assert len(spans) == 1
+    span = spans[0]
+    attrs = span.attrs
+    assert span.text == "Janie"
+    assert attrs["trigger"] == "aka"
+    assert attrs["alias_kind"] == "nickname"
+
+
+def test_fka(det: AliasDetector) -> None:
+    text = 'Robert Roe f/k/a "Rob Roe"'
+    span = det.detect(text)[0]
+    assert span.text == "Rob Roe"
+    assert span.attrs["trigger"] == "fka"
+
+
+def test_dba(det: AliasDetector) -> None:
+    text = 'Widgets Inc., d/b/a "Acme Widgets"'
+    span = det.detect(text)[0]
+    assert span.text == "Acme Widgets"
+    assert span.attrs["trigger"] == "dba"
+
+
+def test_boundary_and_quotes(det: AliasDetector) -> None:
+    text = '(hereinafter "Buyer"),'
+    span = det.detect(text)[0]
+    start = text.index('"Buyer"') + 1
+    assert (span.start, span.end) == (start, start + len("Buyer"))
+    assert span.attrs["quote_style"] is not None
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "The bank shall hereinafter be referred to as the institution",
+        "aka the party",
+        "\u201cjohnny\u201d",
+    ],
+)
+def test_negatives(det: AliasDetector, text: str) -> None:
+    assert det.detect(text) == []
+
+
+def test_offsets_and_dedup(det: AliasDetector) -> None:
+    text = 'Jane Smith, a/k/a "Janie" and also a/k/a "Janie"'
+    spans = det.detect(text)
+    assert len(spans) == 2
+    assert spans[0].text == spans[1].text == "Janie"
+    assert spans[0].start != spans[1].start
+    assert all(span.label is EntityLabel.ALIAS_LABEL for span in spans)
+
+
+def test_detector_protocol() -> None:
+    det = AliasDetector()
+    assert isinstance(det, Detector)


### PR DESCRIPTION
## Summary
- detect alias labels introduced via hereinafter/hereafter, AKA/FKA/DBA phrases
- record nearby subject text or guesses with role awareness
- document legal alias handling and add unit tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src pytest tests/test_detect_aliases.py -q` *(fails: ModuleNotFoundError: No module named 'stdnum')*


------
https://chatgpt.com/codex/tasks/task_e_68b35b95a88c83258bab31cccbb3de74