### PR TITLE
feat(detect): add spaCy-based NER detector with fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ as ``ALIAS_LABEL`` spans.  Only the alias term itself is captured – for exampl
 When a subject name appears nearby, the detector records it so later stages can
 link all references to a consistent pseudonym.
 
+## NER (optional)
+
+Named-entity recognition for people, organizations and locations is provided
+via spaCy when available. Install the optional dependencies with
+`pip install .[ner]` and choose a model through
+`config.detectors.ner.model` (defaults to ``en_core_web_trf``). If spaCy or the
+model is unavailable, the detector falls back to lightweight pattern rules or a
+pure-Python regex engine. Setting `config.detectors.ner.require` to `true`
+raises an error instead of falling back.
+
 ## Quick start (CLI)
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ dev = [
     "pytest>=7.0",
     "types-PyYAML",
 ]
+ner = [
+    "spacy>=3.7,<3.8",
+    "spacy-transformers>=1.3,<1.4",
+]
 
 [tool.setuptools.package-dir]
 "" = "src"
@@ -76,4 +80,8 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["typer.testing"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["spacy", "spacy.*"]
 ignore_missing_imports = true

--- a/src/redactor/detect/__init__.py
+++ b/src/redactor/detect/__init__.py
@@ -7,6 +7,7 @@ from .bank_org import BankOrgDetector
 from .date_dob import DOBDetector
 from .date_generic import DateGenericDetector
 from .email import EmailDetector
+from .ner_spacy import SpacyNERDetector
 from .phone import PhoneDetector
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "DateGenericDetector",
     "DOBDetector",
     "AliasDetector",
+    "SpacyNERDetector",
 ]

--- a/src/redactor/detect/ner_spacy.py
+++ b/src/redactor/detect/ner_spacy.py
@@ -1,22 +1,327 @@
-"""spaCy-based NER detector.
+"""spaCy-based named-entity detector with graceful fallbacks.
 
-Purpose:
-    Use spaCy's statistical models to find entities not covered by rules.
+This detector extracts PERSON, ORG and GPE/LOC mentions using spaCy when
+available.  It supports three operation modes:
 
-Key responsibilities:
-    - Load spaCy language models lazily.
-    - Convert model entities to `EntitySpan` objects.
+* **spacy** – the configured spaCy model is loaded lazily.  Transformer models
+  (names containing ``"trf"``) receive a base confidence of ``0.95`` while
+  smaller models default to ``0.92``.
+* **ruler_fallback** – spaCy is installed but the model cannot be loaded.
+  A lightweight ``blank("en")`` pipeline with an ``EntityRuler`` provides
+  heuristic patterns with a confidence of ``0.88``.
+* **regex_fallback** – spaCy is entirely unavailable.  Pure regular
+  expressions are used with a conservative confidence of ``0.80``.
 
-Inputs/Outputs:
-    - Inputs: text string.
-    - Outputs: list of `EntitySpan` from spaCy entities.
-
-Public contracts (planned):
-    - `detect(text)`: Run spaCy NER on text.
-
-Notes/Edge cases:
-    - Heavy dependency; module should fail gracefully if spaCy is missing.
-
-Dependencies:
-    - `spacy` (optional, heavy).
+All modes trim trailing punctuation from spans and suppress obvious role words
+such as ``Buyer`` or ``Seller``.  Fully lowercase strings or single-token
+uppercase strings are ignored to reduce false positives.  Resolution of
+overlapping spans across detectors is handled elsewhere in the pipeline.
 """
+
+from __future__ import annotations
+
+import re
+
+from redactor.config import ConfigModel
+
+from .base import DetectionContext, EntityLabel, EntitySpan
+
+__all__ = ["SpacyNERDetector", "get_detector"]
+
+# ---------------------------------------------------------------------------
+# Constants and helpers
+# ---------------------------------------------------------------------------
+
+ROLE_LEXICON = {
+    "Buyer",
+    "Seller",
+    "Lender",
+    "Borrower",
+    "Landlord",
+    "Tenant",
+    "Guarantor",
+    "Licensor",
+    "Licensee",
+    "Plaintiff",
+    "Defendant",
+    "Petitioner",
+    "Respondent",
+    "Trustee",
+    "Executor",
+    "Administrator",
+    "Assignor",
+    "Assignee",
+    "Discloser",
+    "Recipient",
+}
+
+TRAILING_PUNCTUATION = ")]}\};:,.!?»”’>"
+
+
+def _trim_right_punct(text: str, start: int, end: int) -> tuple[int, int]:
+    """Trim trailing punctuation from ``text[start:end]``."""
+
+    while end > start and text[end - 1] in TRAILING_PUNCTUATION:
+        end -= 1
+    return start, end
+
+
+# Regex patterns for pure Python fallback.
+PERSON_RE = re.compile(
+    r"\b("  # start
+    r"[A-Z][a-z]+(?:[\'’\-][A-Z][a-z]+)?"
+    r"(?:\s+[A-Z][a-z]+(?:[\'’\-][A-Z][a-z]+)?){1,3}"  # additional tokens
+    r")\b"
+)
+
+ORG_RE = re.compile(
+    r"\b("  # start
+    r"[A-Z][\w&.\'’-]*"
+    r"(?:\s+[A-Z][\w&.\'’-]*)*"  # middle tokens
+    r"\s+(?:Inc\.|LLC|LLP|Ltd\.?|PLC|N\.?A\.?|N\.?V\.?|Company|Corp\.|Bank|Trust|Credit\s+Union)"
+    r")\b"
+)
+
+GPE_RE = re.compile(
+    r"\b("  # start
+    r"[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*"  # city words
+    r",\s*[A-Z]{2}"
+    r")\b"
+)
+
+
+def _is_role(text: str) -> bool:
+    """Return ``True`` if ``text`` is a role word in the lexicon."""
+
+    return text.strip("\"'“”‘’") in ROLE_LEXICON
+
+
+def _is_noise(text: str) -> bool:
+    """Return ``True`` if ``text`` is obviously not a name."""
+
+    if text.islower():
+        return True
+    tokens = text.split()
+    if len(tokens) == 1 and text.isupper():
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Detector implementation
+# ---------------------------------------------------------------------------
+
+
+class SpacyNERDetector:
+    """Detect PERSON/ORG/GPE spans using spaCy with fallbacks."""
+
+    def __init__(self, cfg: ConfigModel):
+        self._cfg = cfg
+        self._model_name = cfg.detectors.ner.model
+        self._enabled = cfg.detectors.ner.enabled
+        self._require = cfg.detectors.ner.require
+        self._nlp: object | None = None
+        self._mode: str | None = None
+        self._confidence_base: float = 0.0
+
+    def name(self) -> str:  # pragma: no cover - trivial
+        return "ner_spacy"
+
+    # ------------------------------------------------------------------
+    # Pipeline initialisation
+    # ------------------------------------------------------------------
+    def _ensure_pipeline(self) -> None:
+        if self._mode is not None:
+            return
+
+        try:
+            import spacy
+            from spacy.language import Language  # noqa: F401 - type hint only
+        except Exception as e:  # pragma: no cover - import guard
+            if self._require:
+                raise RuntimeError(
+                    "spaCy is required for NER detection. Install with `pip install redactor[ner]`."
+                ) from e
+            self._mode = "regex_fallback"
+            return
+
+        # Try to load requested model.
+        try:
+            self._nlp = spacy.load(self._model_name)
+            self._mode = "spacy"
+            self._confidence_base = 0.95 if "trf" in self._model_name else 0.92
+            return
+        except Exception as e:
+            if self._model_name == "en_core_web_trf":
+                try:
+                    self._nlp = spacy.load("en_core_web_sm")
+                    self._model_name = "en_core_web_sm"
+                    self._mode = "spacy"
+                    self._confidence_base = 0.92
+                    return
+                except Exception:
+                    pass
+            if self._require:
+                raise RuntimeError(
+                    "spaCy model '%s' is not available. Install with `pip install redactor[ner]`."
+                    % self._model_name
+                ) from e
+
+        # Build EntityRuler fallback
+        nlp = spacy.blank("en")
+        ruler = nlp.add_pipe("entity_ruler")
+
+        patterns: list[dict[str, object]] = []
+
+        name_token = {"TEXT": {"REGEX": r"[A-Z][a-z]+(?:[\'’\-][A-Z][a-z]+)?"}}
+        for length in range(2, 5):
+            patterns.append({"label": "PERSON", "pattern": [name_token] * length})
+
+        org_token = {"TEXT": {"REGEX": r"[A-Z][\w&.\'’-]*"}}
+        org_suffixes = [
+            ["Inc."],
+            ["LLC"],
+            ["LLP"],
+            ["Ltd."],
+            ["Ltd"],
+            ["PLC"],
+            ["N.A."],
+            ["N.V."],
+            ["Company"],
+            ["Corp."],
+            ["Bank"],
+            ["Trust"],
+            ["Credit", "Union"],
+        ]
+        for pre in range(1, 4):  # number of tokens before suffix
+            for suf in org_suffixes:
+                patterns.append(
+                    {
+                        "label": "ORG",
+                        "pattern": [org_token] * pre + [{"TEXT": s} for s in suf],
+                    }
+                )
+
+        city_token = {"TEXT": {"REGEX": r"[A-Z][a-z]+"}}
+        for length in range(1, 4):
+            pattern = [city_token] * length + [
+                {"TEXT": ","},
+                {"TEXT": {"REGEX": r"[A-Z]{2}"}},
+            ]
+            patterns.append({"label": "GPE", "pattern": pattern})
+
+        ruler.add_patterns(patterns)
+
+        self._nlp = nlp
+        self._mode = "ruler_fallback"
+        self._confidence_base = 0.88
+
+    # ------------------------------------------------------------------
+    # Detection
+    # ------------------------------------------------------------------
+    def detect(self, text: str, context: DetectionContext | None = None) -> list[EntitySpan]:
+        if not self._enabled:
+            return []
+
+        if self._mode is None:
+            self._ensure_pipeline()
+
+        spans: list[EntitySpan] = []
+
+        if self._mode == "spacy" or self._mode == "ruler_fallback":
+            assert self._nlp is not None
+            doc = self._nlp(text)  # type: ignore[operator]
+            for ent in doc.ents:
+                if ent.label_ not in {"PERSON", "ORG", "GPE", "LOC"}:
+                    continue
+                start, end = _trim_right_punct(text, ent.start_char, ent.end_char)
+                label_map = {
+                    "PERSON": EntityLabel.PERSON,
+                    "ORG": EntityLabel.ORG,
+                    "GPE": EntityLabel.GPE,
+                    "LOC": EntityLabel.LOC,
+                }
+                label = label_map[ent.label_]
+                span_text = text[start:end]
+                if label is EntityLabel.PERSON and _is_role(span_text):
+                    continue
+                if _is_noise(span_text):
+                    continue
+
+                attrs: dict[str, object] = {"mode": self._mode, "spacy_label": ent.label_}
+                if self._mode == "spacy":
+                    attrs["model"] = self._model_name
+                    confidence = self._confidence_base
+                else:  # ruler fallback
+                    confidence = self._confidence_base
+
+                spans.append(
+                    EntitySpan(start, end, span_text, label, "ner_spacy", confidence, attrs)
+                )
+
+        else:  # regex fallback
+            confidence = 0.80
+            for match in PERSON_RE.finditer(text):
+                start, end = _trim_right_punct(text, *match.span(0))
+                span_text = text[start:end]
+                if _is_role(span_text) or _is_noise(span_text):
+                    continue
+                spans.append(
+                    EntitySpan(
+                        start,
+                        end,
+                        span_text,
+                        EntityLabel.PERSON,
+                        "ner_spacy",
+                        confidence,
+                        {"mode": "regex"},
+                    )
+                )
+
+            for match in ORG_RE.finditer(text):
+                start, end = _trim_right_punct(text, *match.span(0))
+                span_text = text[start:end]
+                if _is_noise(span_text):
+                    continue
+                spans.append(
+                    EntitySpan(
+                        start,
+                        end,
+                        span_text,
+                        EntityLabel.ORG,
+                        "ner_spacy",
+                        confidence,
+                        {"mode": "regex"},
+                    )
+                )
+
+            for match in GPE_RE.finditer(text):
+                start, end = _trim_right_punct(text, *match.span(0))
+                span_text = text[start:end]
+                if _is_noise(span_text):
+                    continue
+                spans.append(
+                    EntitySpan(
+                        start,
+                        end,
+                        span_text,
+                        EntityLabel.GPE,
+                        "ner_spacy",
+                        confidence,
+                        {"mode": "regex"},
+                    )
+                )
+
+        # De-duplicate spans by (start, end)
+        unique: dict[tuple[int, int], EntitySpan] = {}
+        for span in spans:
+            key = (span.start, span.end)
+            if key not in unique:
+                unique[key] = span
+        return sorted(unique.values(), key=lambda s: s.start)
+
+
+def get_detector(cfg: ConfigModel) -> SpacyNERDetector:
+    """Return a :class:`SpacyNERDetector` instance."""
+
+    return SpacyNERDetector(cfg)

--- a/tests/test_detect_ner.py
+++ b/tests/test_detect_ner.py
@@ -1,0 +1,68 @@
+import pytest
+
+from redactor.config.schema import load_config
+from redactor.detect.base import EntityLabel
+from redactor.detect.ner_spacy import SpacyNERDetector
+
+
+@pytest.fixture
+def det() -> SpacyNERDetector:
+    cfg = load_config()
+    return SpacyNERDetector(cfg)
+
+
+def test_person_org_basic(det: SpacyNERDetector) -> None:
+    text = "John Doe executed the agreement with Acme LLC."
+    spans = det.detect(text)
+    person = next(s for s in spans if s.label is EntityLabel.PERSON and s.text == "John Doe")
+    org = next(s for s in spans if s.label is EntityLabel.ORG and s.text == "Acme LLC")
+    assert person.start == text.index("John Doe")
+    assert person.end == person.start + len("John Doe")
+    assert org.start == text.index("Acme LLC")
+    assert org.end == org.start + len("Acme LLC")
+
+
+def test_boundary_trimming(det: SpacyNERDetector) -> None:
+    text = "(John Doe),"
+    spans = det.detect(text)
+    person = next(s for s in spans if s.label is EntityLabel.PERSON)
+    assert person.text == "John Doe"
+    start = text.index("John Doe")
+    assert person.start == start
+    assert person.end == start + len("John Doe")
+
+
+def test_role_suppression(det: SpacyNERDetector) -> None:
+    text = 'hereinafter "Buyer"'
+    spans = det.detect(text)
+    assert all(s.text != "Buyer" for s in spans)
+
+
+def test_gpe_optional(det: SpacyNERDetector) -> None:
+    text = "Meeting in San Francisco, CA today."
+    spans = det.detect(text)
+    gpe_spans = [s for s in spans if s.label is EntityLabel.GPE]
+    if gpe_spans:
+        assert gpe_spans[0].text == "San Francisco, CA"
+
+
+def test_spacy_specific() -> None:
+    pytest.importorskip("spacy")
+    cfg = load_config()
+    cfg.detectors.ner.enabled = True
+    cfg.detectors.ner.require = False
+    det = SpacyNERDetector(cfg)
+    text = "Jane Smith met at Example Ltd."
+    spans = det.detect(text)
+    person = next(s for s in spans if s.label is EntityLabel.PERSON and s.text == "Jane Smith")
+    org = next(s for s in spans if s.label is EntityLabel.ORG and s.text == "Example Ltd.")
+    assert person.attrs["mode"] in {"spacy", "ruler_fallback"}
+    assert org.attrs["mode"] in {"spacy", "ruler_fallback"}
+
+
+def test_duplicate_offsets(det: SpacyNERDetector) -> None:
+    text = "Acme LLC met with Acme LLC"
+    spans = det.detect(text)
+    org_spans = [s for s in spans if s.label is EntityLabel.ORG]
+    assert len(org_spans) == 2
+    assert org_spans[0].start != org_spans[1].start


### PR DESCRIPTION
## Summary
- implement `SpacyNERDetector` with spaCy, entity ruler, and regex fallbacks and role suppression
- expose NER detector and document optional spaCy support
- add tests covering detection, trimming, suppression, and duplicates

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src pytest -q` *(fails: No module named 'stdnum'; attempted to `pip install python-stdnum` but proxy returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b35de0dc4c8325a9b8d978159ac4f4