### PR TITLE
feat(replace): plan deterministic pseudonym replacements and apply idempotently

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,22 @@ pseudonym replacements remain consistent.  Role aliases like ``Buyer`` can be
 kept verbatim by setting ``redact.alias_labels`` to ``"keep_roles"`` – they are
 still linked for clustering but marked to skip replacement.
 
+## Replacement planning and application
+
+Detected spans are converted into a replacement plan that records the
+character offsets and final pseudonyms to insert.  Entries are applied in
+reverse order so indices remain valid.  Role labels may be preserved when
+``redact.alias_labels`` is set to ``"keep_roles"`` and generic dates remain
+unless ``redact.generic_dates`` is enabled.
+
+```text
+Before: John Doe (the "Buyer") was born on July 4, 1982.
+After:  Alan Smith (the "Buyer") was born on May 9, 1960.
+```
+
+The applied plan provides an audit trail showing which spans were replaced and
+with what pseudonyms.
+
 ## NER (optional)
 
 Named-entity recognition for people, organizations and locations is provided

--- a/src/redactor/replace/applier.py
+++ b/src/redactor/replace/applier.py
@@ -1,22 +1,73 @@
 """Replacement plan applier.
 
-Purpose:
-    Execute a replacement plan to produce redacted text.
-
-Key responsibilities:
-    - Apply replacements in a stable order.
-    - Optionally preserve unmatched text segments.
-
-Inputs/Outputs:
-    - Inputs: original text and replacement plan.
-    - Outputs: redacted text string.
-
-Public contracts (planned):
-    - `apply_plan(text, plan)`: Return redacted text.
-
-Notes/Edge cases:
-    - Must handle overlapping or nested replacements safely.
-
-Dependencies:
-    - Standard library only.
+Plan entries reference half‑open character ranges ``[start, end)`` in the
+original text.  To avoid shifting indices the applier sorts plan entries in
+reverse order by start position and performs replacements from the end of the
+text towards the beginning.  Basic validation ensures spans do not overlap and
+fall within bounds.  Applying the same plan to already‑redacted text is
+idempotent: if the target slice already matches the replacement it is left
+untouched.
 """
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Iterable
+
+from redactor.utils.errors import OverlapError, SpanOutOfBoundsError
+
+from .plan_builder import PlanEntry
+
+__all__ = ["apply_plan"]
+
+
+def _validate_plan(plan: Iterable[PlanEntry], text_len: int) -> None:
+    ordered = sorted(plan, key=lambda p: p.start)
+    prev_end = 0
+    for entry in ordered:
+        if entry.start < prev_end:
+            msg = f"plan entries overlap: {prev_end} > {entry.start}"
+            raise OverlapError(msg)
+        if not (0 <= entry.start <= entry.end <= text_len):
+            msg = f"plan entry out of bounds: {entry.start}-{entry.end}"
+            raise SpanOutOfBoundsError(msg)
+        prev_end = entry.end
+
+
+def apply_plan(text: str, plan: list[PlanEntry]) -> tuple[str, list[PlanEntry]]:
+    """Apply ``plan`` to ``text`` returning ``(new_text, applied_plan)``."""
+
+    if not plan:
+        return text, []
+
+    _validate_plan(plan, len(text))
+    ordered = sorted(plan, key=lambda p: (p.start, p.end), reverse=True)
+
+    pieces: list[str] = []
+    cursor = len(text)
+    applied: list[PlanEntry] = []
+
+    for idx, entry in enumerate(ordered):
+        start = entry.start
+        end = entry.end
+        repl = entry.replacement
+        existing_end = start + len(repl)
+        if text[start:existing_end] == repl:
+            pieces.append(text[existing_end:cursor])
+            pieces.append(repl)
+            cursor = start
+        else:
+            pieces.append(text[end:cursor])
+            pieces.append(repl)
+            cursor = start
+        applied_meta = dict(entry.meta)
+        applied_meta["applied_index"] = idx
+        applied.append(
+            replace(
+                entry,
+                meta=applied_meta,
+            )
+        )
+    pieces.append(text[:cursor])
+    new_text = "".join(reversed(pieces))
+    return new_text, applied

--- a/src/redactor/replace/plan_builder.py
+++ b/src/redactor/replace/plan_builder.py
@@ -1,22 +1,284 @@
 """Replacement plan builder.
 
-Purpose:
-    Construct a set of operations to replace detected spans.
+This module translates resolved :class:`~redactor.detect.base.EntitySpan`
+objects into concrete replacement operations.  Each span is mapped to a
+pseudonym according to its :class:`~redactor.detect.base.EntityLabel` and
+case/format is preserved.  The resulting plan is safe to apply in reverse order
+without shifting indices.
 
-Key responsibilities:
-    - Combine spans and pseudonyms into an ordered plan.
-    - Ensure offsets remain valid after sequential replacements.
-
-Inputs/Outputs:
-    - Inputs: original text, list of spans, pseudonym generator.
-    - Outputs: replacement plan data structure.
-
-Public contracts (planned):
-    - `build_plan(text, spans, pseudo)`: Create plan for text replacement.
-
-Notes/Edge cases:
-    - Overlapping spans must be resolved before plan creation.
-
-Dependencies:
-    - `link` and `pseudo` modules.
+The builder enforces non‑overlapping spans, handles label specific policy such
+as keeping role aliases or generic dates, and guarantees deterministic output by
+seeding :class:`~redactor.pseudo.generator.PseudonymGenerator` with the provided
+configuration and text.  When a generated replacement accidentally matches the
+original span text a salted key is used to deterministically retry until a
+different value is produced.
 """
+
+from __future__ import annotations
+
+import calendar
+import re
+from dataclasses import dataclass
+from typing import Callable, cast
+
+from redactor.config import ConfigModel
+from redactor.detect.base import EntityLabel, EntitySpan
+from redactor.pseudo import PseudonymGenerator, case_preserver, number_rules
+from redactor.utils.textspan import ensure_non_overlapping
+
+__all__ = ["PlanEntry", "build_replacement_plan"]
+
+
+@dataclass(slots=True)
+class PlanEntry:
+    """Description of a single replacement operation."""
+
+    start: int
+    end: int
+    replacement: str
+    label: EntityLabel
+    entity_id: str | None
+    span_id: str | None
+    meta: dict[str, object]
+
+
+def _ensure_diff(original: str, key: str, builder: Callable[[str], str]) -> str:
+    """Return ``builder`` output ensuring it differs from ``original``."""
+
+    for salt in ("", ":1", ":2"):
+        candidate = builder(key + salt if salt else key)
+        if candidate != original:
+            return candidate
+    return candidate
+
+
+def _generate_fake_date_like(
+    source_text: str,
+    attrs: dict[str, object],
+    *,
+    key: str,
+    gen: PseudonymGenerator,
+) -> str:
+    """Return a deterministic fake date mirroring ``source_text`` style."""
+
+    fmt = cast(str | None, attrs.get("format"))
+    normalized = cast(str | None, attrs.get("normalized"))
+
+    def draw(rng_key: str) -> tuple[int, int, int, str]:
+        rng = gen.rng("DOB", rng_key)
+        year = rng.randint(1930, 2005)
+        month = rng.randint(1, 12)
+        if month == 2:
+            leap = year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+            max_day = 29 if leap else 28
+        elif month in {1, 3, 5, 7, 8, 10, 12}:
+            max_day = 31
+        else:
+            max_day = 30
+        day = rng.randint(1, max_day)
+        return year, month, day, f"{year:04d}-{month:02d}-{day:02d}"
+
+    year, month, day, norm = draw(key)
+    if normalized:
+        for salt in (":1", ":2"):
+            if norm != normalized:
+                break
+            year, month, day, norm = draw(f"{key}{salt}")
+
+    if fmt == "month_name_mdY":
+        month_str = calendar.month_name[month]
+        return f"{month_str} {day}, {year}"
+    if fmt == "month_name_dmY":
+        month_str = calendar.month_name[month]
+        return f"{day} {month_str} {year}"
+    if fmt == "mdY_numeric":
+        m = re.match(r"(\d{1,2})/(\d{1,2})/(\d{4})", source_text)
+        if m:
+            month_fmt = f"{month:0{len(m.group(1))}d}"
+            day_fmt = f"{day:0{len(m.group(2))}d}"
+            return f"{month_fmt}/{day_fmt}/{year:04d}"
+        return f"{month}/{day}/{year}"
+    # default ISO format
+    return norm
+
+
+def build_replacement_plan(
+    text: str,
+    spans: list[EntitySpan],
+    cfg: ConfigModel,
+    *,
+    clusters: dict[str, dict[str, object]] | None = None,
+) -> list[PlanEntry]:
+    """Return replacement plan entries for ``spans`` within ``text``."""
+
+    _ = clusters  # unused placeholder for future expansion
+    ensure_non_overlapping(spans)
+    gen = PseudonymGenerator(cfg, text=text)
+    plan: list[PlanEntry] = []
+
+    for sp in sorted(spans, key=lambda s: s.start):
+        if cast(bool, sp.attrs.get("skip_replacement")):
+            continue
+
+        replacement: str | None = None
+        label = sp.label
+
+        if label is EntityLabel.PERSON:
+            key = sp.entity_id or sp.text
+
+            def build_person(k: str, text: str = sp.text) -> str:
+                return case_preserver.format_like(text, gen.person_name_like(text, key=k))
+
+            replacement = _ensure_diff(sp.text, key, build_person)
+        elif label is EntityLabel.ORG:
+            key = sp.entity_id or sp.text
+
+            def build_org(k: str, text: str = sp.text) -> str:
+                return case_preserver.format_like(text, gen.org_name_like(text, key=k))
+
+            replacement = _ensure_diff(sp.text, key, build_org)
+        elif label is EntityLabel.BANK_ORG:
+            key = sp.entity_id or sp.text
+
+            def build_bank(k: str, text: str = sp.text) -> str:
+                return case_preserver.format_like(text, gen.bank_org_like(text, key=k))
+
+            replacement = _ensure_diff(sp.text, key, build_bank)
+        elif label is EntityLabel.ADDRESS_BLOCK:
+            key_attr = cast(str | None, sp.attrs.get("normalized_block"))
+            key = sp.entity_id or key_attr or sp.text
+            line_kinds = cast(list[str] | None, sp.attrs.get("line_kinds"))
+
+            def build_addr(
+                k: str,
+                text: str = sp.text,
+                line_kinds: list[str] | None = line_kinds,
+            ) -> str:
+                return gen.address_block_like(text, key=k, line_kinds=line_kinds)
+
+            replacement = _ensure_diff(sp.text, key, build_addr)
+        elif label is EntityLabel.EMAIL:
+            base_local = cast(str, sp.attrs.get("base_local") or "").lower()
+            tag = cast(str | None, sp.attrs.get("tag"))
+            key = base_local or sp.text
+
+            def build_email(token_key: str, tag: str | None = tag) -> str:
+                token = gen.token("EMAIL", token_key, length=10)
+                local = f"u{token}"
+                if tag:
+                    local = f"{local}+t{token[-3:]}"
+                return f"{local}@example.org"
+
+            replacement = _ensure_diff(sp.text, key, build_email)
+        elif label is EntityLabel.PHONE:
+            key = sp.entity_id or sp.text
+
+            def build_phone(k: str, text: str = sp.text) -> str:
+                return number_rules.generate_generic_digits_like(text, key=k, gen=gen)
+
+            replacement = _ensure_diff(sp.text, key, build_phone)
+        elif label is EntityLabel.ACCOUNT_ID:
+            subtype = cast(str | None, sp.attrs.get("subtype")) or "generic"
+            key = sp.entity_id or sp.text
+            if subtype == "cc":
+
+                def build_cc(k: str, text: str = sp.text) -> str:
+                    return number_rules.generate_cc_like(text, key=k, gen=gen)
+
+                replacement = _ensure_diff(sp.text, key, build_cc)
+            elif subtype == "routing_aba":
+
+                def build_routing(k: str, text: str = sp.text) -> str:
+                    return number_rules.generate_routing_like(text, key=k, gen=gen)
+
+                replacement = _ensure_diff(sp.text, key, build_routing)
+            elif subtype == "iban":
+
+                def build_iban(k: str, text: str = sp.text) -> str:
+                    return number_rules.generate_iban_like(text, key=k, gen=gen)
+
+                replacement = _ensure_diff(sp.text, key, build_iban)
+            elif subtype == "ssn":
+
+                def build_ssn(k: str, text: str = sp.text) -> str:
+                    return number_rules.generate_ssn_like(text, key=k, gen=gen)
+
+                replacement = _ensure_diff(sp.text, key, build_ssn)
+            elif subtype == "ein":
+
+                def build_ein(k: str, text: str = sp.text) -> str:
+                    return number_rules.generate_ein_like(text, key=k, gen=gen)
+
+                replacement = _ensure_diff(sp.text, key, build_ein)
+            elif subtype == "swift_bic":
+
+                def build_bic(k: str, text: str = sp.text) -> str:
+                    return case_preserver.match_case(text, gen.account_number(k, kind="bic"))
+
+                replacement = _ensure_diff(sp.text, key, build_bic)
+            else:
+
+                def build_generic(k: str, text: str = sp.text) -> str:
+                    return number_rules.generate_generic_digits_like(text, key=k, gen=gen)
+
+                replacement = _ensure_diff(sp.text, key, build_generic)
+        elif label is EntityLabel.DOB:
+            key = sp.entity_id or cast(str | None, sp.attrs.get("normalized")) or sp.text
+            replacement = _generate_fake_date_like(sp.text, sp.attrs, key=key, gen=gen)
+        elif label is EntityLabel.DATE_GENERIC:
+            if cfg.redact.generic_dates:
+                key = sp.entity_id or cast(str | None, sp.attrs.get("normalized")) or sp.text
+                replacement = _generate_fake_date_like(sp.text, sp.attrs, key=key, gen=gen)
+        elif label is EntityLabel.ALIAS_LABEL:
+            alias_kind = cast(str | None, sp.attrs.get("alias_kind"))
+            cluster_id = cast(str | None, sp.attrs.get("cluster_id")) or sp.entity_id
+            if alias_kind == "role":
+                if cfg.redact.alias_labels == "keep_roles":
+                    replacement = None
+                else:
+
+                    def build_role(k: str, text: str = sp.text) -> str:
+                        token = gen.token("ROLE", k, length=2)
+                        letter = chr(ord("A") + (int(token, 32) % 26))
+                        return case_preserver.format_like(text, f"Party {letter}")
+
+                    replacement = _ensure_diff(sp.text, cluster_id or sp.text, build_role)
+            else:
+                key = cluster_id or sp.text
+
+                def build_nick(k: str, text: str = sp.text) -> str:
+                    pseudo_full = gen.person_name_like("John Doe", key=k)
+                    first = pseudo_full.split()[0] if pseudo_full.strip() else pseudo_full
+                    return case_preserver.format_like(text, first)
+
+                replacement = _ensure_diff(sp.text, key, build_nick)
+        else:
+            replacement = None
+
+        if replacement is None:
+            continue
+
+        meta: dict[str, object] = {
+            "source": sp.source,
+            "span_id": sp.span_id,
+            "subtype": sp.attrs.get("subtype"),
+            "source_label_text": sp.text,
+            "skip_replacement": False,
+        }
+        if label is EntityLabel.ALIAS_LABEL:
+            meta["alias_kind"] = sp.attrs.get("alias_kind")
+            if sp.entity_id:
+                meta["cluster_id"] = sp.entity_id
+        plan.append(
+            PlanEntry(
+                start=sp.start,
+                end=sp.end,
+                replacement=replacement,
+                label=label,
+                entity_id=sp.entity_id,
+                span_id=sp.span_id,
+                meta=meta,
+            )
+        )
+
+    return plan

--- a/tests/test_replace_plan_and_apply.py
+++ b/tests/test_replace_plan_and_apply.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import re
+
+from redactor.config import load_config
+from redactor.detect.base import EntityLabel, EntitySpan
+from redactor.pseudo import case_preserver
+from redactor.replace import applier, plan_builder
+
+
+def _span(
+    start: int,
+    end: int,
+    text: str,
+    label: EntityLabel,
+    *,
+    attrs: dict[str, object] | None = None,
+    entity_id: str | None = None,
+) -> EntitySpan:
+    return EntitySpan(start, end, text, label, "test", 0.9, attrs or {}, entity_id=entity_id)
+
+
+def test_person_and_alias_nickname_consistency() -> None:
+    cfg = load_config()
+    text = 'John Doe, hereinafter "Morgan". Later, Morgan executed the deed.'
+    spans = [
+        _span(0, 8, "John Doe", EntityLabel.PERSON, entity_id="p1"),
+        _span(
+            23,
+            29,
+            "Morgan",
+            EntityLabel.ALIAS_LABEL,
+            attrs={"alias_kind": "nickname", "cluster_id": "p1"},
+            entity_id="p1",
+        ),
+        _span(
+            39,
+            45,
+            "Morgan",
+            EntityLabel.ALIAS_LABEL,
+            attrs={"alias_kind": "nickname", "cluster_id": "p1"},
+            entity_id="p1",
+        ),
+    ]
+    plan = plan_builder.build_replacement_plan(text, spans, cfg)
+    new_text, _ = applier.apply_plan(text, plan)
+    person_repl = next(e.replacement for e in plan if e.label is EntityLabel.PERSON)
+    alias_repls = [e.replacement for e in plan if e.label is EntityLabel.ALIAS_LABEL]
+    assert len(alias_repls) == 2
+    assert len(set(alias_repls)) == 1
+    expected_alias = case_preserver.format_like("Morgan", person_repl.split()[0])
+    assert alias_repls[0] == expected_alias
+    assert "John Doe" not in new_text
+    assert "Morgan" not in new_text
+
+
+def test_role_alias_kept_when_policy_keep_roles() -> None:
+    cfg = load_config()
+    cfg.redact.alias_labels = "keep_roles"
+    text = 'John Doe (the "Buyer") signed. Buyer then paid.'
+    spans = [
+        _span(0, 8, "John Doe", EntityLabel.PERSON, entity_id="p1"),
+        _span(
+            15,
+            20,
+            "Buyer",
+            EntityLabel.ALIAS_LABEL,
+            attrs={"alias_kind": "role", "cluster_id": "p1"},
+            entity_id="p1",
+        ),
+        _span(
+            31,
+            36,
+            "Buyer",
+            EntityLabel.ALIAS_LABEL,
+            attrs={"alias_kind": "role", "cluster_id": "p1"},
+            entity_id="p1",
+        ),
+    ]
+    plan = plan_builder.build_replacement_plan(text, spans, cfg)
+    assert all(e.label is not EntityLabel.ALIAS_LABEL for e in plan)
+    new_text, _ = applier.apply_plan(text, plan)
+    assert "Buyer" in new_text
+    assert "John Doe" not in new_text
+
+
+def test_address_block_replacement() -> None:
+    cfg = load_config()
+    text = "Address:\n123 Main St\nSpringfield, IL 12345\nEnd."
+    start = text.index("123 Main St")
+    end = text.index("\nEnd.")
+    block = text[start:end]
+    spans = [
+        _span(
+            start,
+            end,
+            block,
+            EntityLabel.ADDRESS_BLOCK,
+            attrs={"line_kinds": ["street", "city_state_zip"]},
+        ),
+    ]
+    plan = plan_builder.build_replacement_plan(text, spans, cfg)
+    repl = plan[0].replacement
+    assert repl.count("\n") == block.count("\n")
+    assert "Main" not in repl and "Springfield" not in repl
+    new_text, _ = applier.apply_plan(text, plan)
+    assert "Main" not in new_text and "Springfield" not in new_text
+
+
+def test_email_and_phone_replacement() -> None:
+    cfg = load_config()
+    text = "Contact: john@example.com, (415) 555-1212."
+    spans = [
+        _span(9, 25, "john@example.com", EntityLabel.EMAIL, attrs={"base_local": "john"}),
+        _span(27, 41, "(415) 555-1212", EntityLabel.PHONE),
+    ]
+    plan = plan_builder.build_replacement_plan(text, spans, cfg)
+    new_text, _ = applier.apply_plan(text, plan)
+    assert "john@example.com" not in new_text
+    assert "@example.org" in new_text
+    assert "(415) 555-1212" not in new_text
+    assert re.search(r"\(\d{3}\) \d{3}-\d{4}", new_text)
+
+
+def test_account_id_replacements() -> None:
+    cfg = load_config()
+    text = (
+        "CC 4111-1111-1111-1111, routing 123456789, IBAN GB82WEST12345698765432, SSN 123-45-6789."
+    )
+    spans = [
+        _span(3, 22, "4111-1111-1111-1111", EntityLabel.ACCOUNT_ID, attrs={"subtype": "cc"}),
+        _span(32, 41, "123456789", EntityLabel.ACCOUNT_ID, attrs={"subtype": "routing_aba"}),
+        _span(48, 70, "GB82WEST12345698765432", EntityLabel.ACCOUNT_ID, attrs={"subtype": "iban"}),
+        _span(76, 87, "123-45-6789", EntityLabel.ACCOUNT_ID, attrs={"subtype": "ssn"}),
+    ]
+    plan = plan_builder.build_replacement_plan(text, spans, cfg)
+    by_sub = {e.meta.get("subtype"): e for e in plan}
+    assert by_sub["cc"].replacement != "4111-1111-1111-1111"
+    assert re.sub(r"\d", "0", by_sub["cc"].replacement) == re.sub(r"\d", "0", "4111-1111-1111-1111")
+    assert by_sub["routing_aba"].replacement.isdigit()
+    assert by_sub["routing_aba"].replacement != "123456789"
+    assert len(by_sub["iban"].replacement) == len("GB82WEST12345698765432")
+    assert by_sub["iban"].replacement[:2] == "GB"
+    assert re.sub(r"\d", "0", by_sub["ssn"].replacement) == "000-00-0000"
+    assert by_sub["ssn"].replacement != "123-45-6789"
+    new_text, _ = applier.apply_plan(text, plan)
+    assert "4111-1111-1111-1111" not in new_text
+    assert "123456789" not in new_text
+    assert "GB82WEST12345698765432" not in new_text
+    assert "123-45-6789" not in new_text
+
+
+def test_dob_vs_generic_date_policy() -> None:
+    cfg = load_config()
+    text = "Date of Birth: July 4, 1982. Executed on July 5, 1982."
+    spans = [
+        _span(
+            15,
+            27,
+            "July 4, 1982",
+            EntityLabel.DOB,
+            attrs={"format": "month_name_mdY", "normalized": "1982-07-04"},
+        ),
+        _span(
+            41,
+            53,
+            "July 5, 1982",
+            EntityLabel.DATE_GENERIC,
+            attrs={"format": "month_name_mdY", "normalized": "1982-07-05"},
+        ),
+    ]
+    plan = plan_builder.build_replacement_plan(text, spans, cfg)
+    assert any(e.label is EntityLabel.DOB for e in plan)
+    assert all(e.label is not EntityLabel.DATE_GENERIC for e in plan)
+    new_text, _ = applier.apply_plan(text, plan)
+    assert "July 4, 1982" not in new_text
+    assert "July 5, 1982" in new_text
+    cfg.redact.generic_dates = True
+    plan2 = plan_builder.build_replacement_plan(text, spans, cfg)
+    new_text2, _ = applier.apply_plan(text, plan2)
+    assert "July 4, 1982" not in new_text2
+    assert "July 5, 1982" not in new_text2
+
+
+def test_adjacent_spans_apply_independently() -> None:
+    cfg = load_config()
+    text = "AliceBob"
+    spans = [
+        _span(0, 5, "Alice", EntityLabel.PERSON, entity_id="p1"),
+        _span(5, 8, "Bob", EntityLabel.PERSON, entity_id="p2"),
+    ]
+    plan = plan_builder.build_replacement_plan(text, spans, cfg)
+    new_text, _ = applier.apply_plan(text, plan)
+    assert "Alice" not in new_text and "Bob" not in new_text
+    assert len(plan) == 2
+
+
+def test_idempotent_application() -> None:
+    cfg = load_config()
+    text = "John Doe"
+    spans = [_span(0, 8, "John Doe", EntityLabel.PERSON, entity_id="p1")]
+    plan = plan_builder.build_replacement_plan(text, spans, cfg)
+    new_text, _ = applier.apply_plan(text, plan)
+    new_text2, _ = applier.apply_plan(new_text, plan)
+    assert new_text2 == new_text
+
+
+def test_deterministic_outputs() -> None:
+    cfg = load_config()
+    text = "Jane Doe met Jane Doe."
+    start = text.index("Jane Doe")
+    spans = [_span(start, start + 8, "Jane Doe", EntityLabel.PERSON, entity_id="p1")]
+    plan1 = plan_builder.build_replacement_plan(text, spans, cfg)
+    red1, _ = applier.apply_plan(text, plan1)
+    plan2 = plan_builder.build_replacement_plan(text, spans, cfg)
+    red2, _ = applier.apply_plan(text, plan2)
+    assert red1 == red2


### PR DESCRIPTION
## Summary
- add PlanEntry dataclass and build_replacement_plan covering all entity labels with policy-aware pseudonyms
- implement reverse-order apply_plan with bounds/overlap checks and idempotence
- document replacement planning and add comprehensive tests

## Testing
- `python -m black --check .`
- `python -m ruff check .`
- `python -m mypy .`
- `PYTHONPATH=src pytest tests/test_replace_plan_and_apply.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b42214e7ac8325b92ba3b2335bf9d6