### PR TITLE
feat(verify): add post-redaction scanner with policy-aware ignore rules and leakage scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,25 @@ model is unavailable, the detector falls back to lightweight pattern rules or a
 pure-Python regex engine. Setting `config.detectors.ner.require` to `true`
 raises an error instead of falling back.
 
+## Verification and leakage scoring
+
+After replacements are applied you can re-scan the redacted text for residual
+PII.  The verification scanner reuses the same detectors and produces a
+structured report with counts by entity label and an overall leakage score.
+
+```python
+from redactor.config import load_config
+from redactor.verify.scanner import scan_text
+
+cfg = load_config()
+report = scan_text("Contact john@acme.com", cfg)
+print(report.counts_by_label)  # {'EMAIL': 1}
+print(report.score)            # 3
+```
+
+The command line interface honours `cfg.verification.fail_on_residual` and will
+exit with a non-zero status when any residual entities are found.
+
 ## Name heuristics
 
 `redactor.detect.names_person` offers dependency-free helpers for judging

--- a/src/redactor/verify/heuristics.py
+++ b/src/redactor/verify/heuristics.py
@@ -1,22 +1,98 @@
-"""Verification heuristics.
+"""Lightweight helpers for verification scanning.
 
-Purpose:
-    Provide lightweight checks for common redaction mistakes.
+This module provides pure functions used by the verification scanner to
+apply policy and synthetic‑safe ignore rules.  They avoid heavy imports so
+that the verification step remains fast and dependency free.
 
-Key responsibilities:
-    - Search for placeholder patterns or obvious artifacts.
-    - Flag suspicious outputs for manual review.
-
-Inputs/Outputs:
-    - Inputs: redacted text.
-    - Outputs: list of heuristic warnings.
-
-Public contracts (planned):
-    - `run(text)`: Return list of heuristic messages.
-
-Notes/Edge cases:
-    - Heuristics should produce minimal false positives.
-
-Dependencies:
-    - Standard library only.
+The helpers cover:
+    * identifying e‑mail domains and phone numbers that are considered
+      inherently safe (e.g. ``example.org`` or ``+1555`` test numbers);
+    * building multisets of replacement strings from an applied plan so
+      detected spans matching our own replacements can be ignored; and
+    * providing the label weight mapping used for leakage scoring.
 """
+
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from typing import Iterable
+
+from redactor.config import ConfigModel
+from redactor.detect.base import EntityLabel
+from redactor.replace.plan_builder import PlanEntry
+
+__all__ = [
+    "is_safe_email_domain",
+    "is_safe_phone_string",
+    "build_replacement_multiset_by_label",
+    "weight_map",
+]
+
+
+_SAFE_EMAIL_DOMAINS = {"example.org", "example.com", "example.net"}
+
+
+def is_safe_email_domain(domain: str) -> bool:
+    """Return ``True`` if ``domain`` is on the allow list.
+
+    The redaction pipeline generates synthetic email addresses using the
+    ``example.*`` domains.  Any match within these domains is treated as safe
+    and ignored by the verification scanner.
+    """
+
+    return domain.lower() in _SAFE_EMAIL_DOMAINS
+
+
+_SAFE_PHONE_RE = re.compile(r"^\+1555\d{7}$")
+
+
+def is_safe_phone_string(s: str) -> bool:
+    """Return ``True`` if ``s`` is a known safe test phone number."""
+
+    return bool(_SAFE_PHONE_RE.match(s))
+
+
+def build_replacement_multiset_by_label(
+    applied_plan: Iterable[PlanEntry] | None,
+) -> dict[EntityLabel, Counter[str]]:
+    """Return mapping of labels to Counters of replacement strings.
+
+    ``applied_plan`` may contain multiple identical replacement strings for
+    the same label.  Using :class:`collections.Counter` allows the scanner to
+    ignore only as many detected matches as were actually produced during
+    replacement, avoiding accidental over‑suppression of genuine residual
+    data.
+    """
+
+    multiset: dict[EntityLabel, Counter[str]] = defaultdict(Counter)
+    if applied_plan is None:
+        return multiset
+    for entry in applied_plan:
+        multiset[entry.label][entry.replacement] += 1
+    return multiset
+
+
+_DEFAULT_WEIGHTS = {
+    EntityLabel.PERSON: 3,
+    EntityLabel.ADDRESS_BLOCK: 3,
+    EntityLabel.DOB: 3,
+    EntityLabel.EMAIL: 3,
+    EntityLabel.ACCOUNT_ID: 3,
+    EntityLabel.PHONE: 2,
+    EntityLabel.BANK_ORG: 1,
+    EntityLabel.ORG: 1,
+    EntityLabel.ALIAS_LABEL: 1,
+    EntityLabel.GPE: 1,
+    EntityLabel.LOC: 1,
+    EntityLabel.DATE_GENERIC: 1,  # adjusted below depending on policy
+}
+
+
+def weight_map(cfg: ConfigModel) -> dict[EntityLabel, int]:
+    """Return entity weights adjusted for policy settings."""
+
+    weights = dict(_DEFAULT_WEIGHTS)
+    if not cfg.redact.generic_dates:
+        weights[EntityLabel.DATE_GENERIC] = 0
+    return weights

--- a/src/redactor/verify/scanner.py
+++ b/src/redactor/verify/scanner.py
@@ -1,22 +1,207 @@
 """Residual sensitive data scanner.
 
-Purpose:
-    Re-scan redacted text for leftover sensitive information.
-
-Key responsibilities:
-    - Run detectors on redacted output to ensure completeness.
-    - Aggregate results for reporting.
-
-Inputs/Outputs:
-    - Inputs: redacted text.
-    - Outputs: list of detected spans or empty list.
-
-Public contracts (planned):
-    - `scan(text)`: Return residual spans after redaction.
-
-Notes/Edge cases:
-    - Must avoid infinite loops if scanners trigger replacements.
-
-Dependencies:
-    - `detect` package.
+This module reuses the existing detectors to analyse already redacted text for
+any leftover personal data.  Unlike the main redaction pipeline the scanner
+does not attempt to merge overlapping spans or modify text – it merely reports
+what it finds and applies a set of policy and synthetic‑safe ignore rules.  The
+resulting :class:`VerificationReport` gives downstream tools a concise summary
+of residual PII and a leakage score.
 """
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from redactor.config import ConfigModel
+from redactor.detect.account_ids import AccountIdDetector
+from redactor.detect.address_libpostal import AddressLineDetector
+from redactor.detect.aliases import AliasDetector
+from redactor.detect.bank_org import BankOrgDetector
+from redactor.detect.base import DetectionContext, Detector, EntityLabel, EntitySpan
+from redactor.detect.date_dob import DOBDetector
+from redactor.detect.date_generic import DateGenericDetector
+from redactor.detect.email import EmailDetector
+from redactor.detect.ner_spacy import SpacyNERDetector
+from redactor.detect.phone import PhoneDetector
+from redactor.replace.plan_builder import PlanEntry
+
+from .heuristics import (
+    build_replacement_multiset_by_label,
+    is_safe_email_domain,
+    is_safe_phone_string,
+    weight_map,
+)
+
+__all__ = [
+    "VerificationFinding",
+    "VerificationReport",
+    "scan_text",
+]
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationFinding:
+    """Information about a detected entity during verification."""
+
+    start: int
+    end: int
+    text: str
+    label: EntityLabel
+    confidence: float
+    attrs: dict[str, object]
+    ignored_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationReport:
+    """Structured result of a verification scan."""
+
+    total_found: int
+    total_ignored: int
+    residual_count: int
+    score: float
+    counts_by_label: dict[str, int]
+    ignored_by_label: dict[str, int]
+    findings: list[VerificationFinding]
+    ignored: list[VerificationFinding]
+    details: dict[str, object] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Detector orchestration
+# ---------------------------------------------------------------------------
+
+
+def _build_detectors(cfg: ConfigModel) -> list[Detector]:
+    detectors: list[Detector] = [
+        EmailDetector(),
+        PhoneDetector(),
+        AccountIdDetector(),
+        BankOrgDetector(),
+        AddressLineDetector(),
+        DateGenericDetector(),
+        DOBDetector(),
+        AliasDetector(),
+    ]
+    if cfg.detectors.ner.enabled:
+        detectors.append(SpacyNERDetector(cfg))
+    return detectors
+
+
+def _entityspan_to_finding(span: EntitySpan) -> VerificationFinding:
+    return VerificationFinding(
+        span.start,
+        span.end,
+        span.text,
+        span.label,
+        span.confidence,
+        dict(span.attrs),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def scan_text(
+    text: str,
+    cfg: ConfigModel,
+    *,
+    applied_plan: list[PlanEntry] | None = None,
+) -> VerificationReport:
+    """Scan ``text`` for residual sensitive data and return a report."""
+
+    detectors = _build_detectors(cfg)
+    context = DetectionContext(locale=cfg.locale, config=cfg)
+    min_conf = cfg.verification.min_confidence
+
+    spans: list[VerificationFinding] = []
+    for det in detectors:
+        for sp in det.detect(text, context):
+            if sp.confidence < min_conf:
+                continue
+            spans.append(_entityspan_to_finding(sp))
+
+    spans.sort(key=lambda f: f.start)
+    total_found = len(spans)
+
+    repl_multiset = build_replacement_multiset_by_label(applied_plan)
+    residual: list[VerificationFinding] = []
+    ignored: list[VerificationFinding] = []
+
+    counts_by_label: dict[str, int] = defaultdict(int)
+    ignored_by_label: dict[str, int] = defaultdict(int)
+
+    weights = weight_map(cfg)
+    score = 0
+
+    for f in spans:
+        reason: str | None = None
+        label = f.label
+
+        counter = repl_multiset.get(label)
+        if counter and counter[f.text] > 0:
+            counter[f.text] -= 1
+            reason = "replacement_match"
+        elif label is EntityLabel.EMAIL:
+            domain = f.attrs.get("domain")
+            if isinstance(domain, str) and is_safe_email_domain(domain):
+                reason = "safe_domain"
+        elif label is EntityLabel.PHONE:
+            if is_safe_phone_string(f.text):
+                reason = "safe_number"
+        elif label is EntityLabel.ACCOUNT_ID:
+            subtype = str(f.attrs.get("subtype", ""))
+            if f.text.startswith("ACCT_"):
+                reason = "token_account"
+            elif subtype == "iban":
+                # rely on replacement_match; nothing special here
+                reason = None
+        elif label is EntityLabel.ALIAS_LABEL and cfg.redact.alias_labels == "keep_roles":
+            reason = "policy_keep_roles"
+        elif label is EntityLabel.DATE_GENERIC and not cfg.redact.generic_dates:
+            reason = "policy_preserve_date"
+
+        if reason is None:
+            residual.append(f)
+            counts_by_label[label.name] += 1
+            score += weights.get(label, 0)
+        else:
+            ignored.append(
+                VerificationFinding(
+                    f.start,
+                    f.end,
+                    f.text,
+                    f.label,
+                    f.confidence,
+                    f.attrs,
+                    reason,
+                )
+            )
+            ignored_by_label[label.name] += 1
+
+    details = {
+        "weights": {lbl.name: w for lbl, w in weights.items()},
+        "min_confidence": min_conf,
+        "generated_at": datetime.utcnow().isoformat(),
+    }
+
+    return VerificationReport(
+        total_found=total_found,
+        total_ignored=len(ignored),
+        residual_count=len(residual),
+        score=score,
+        counts_by_label=dict(counts_by_label),
+        ignored_by_label=dict(ignored_by_label),
+        findings=residual,
+        ignored=ignored,
+        details=details,
+    )

--- a/tests/test_verify_scanner.py
+++ b/tests/test_verify_scanner.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from redactor.config import ConfigModel, load_config
+from redactor.detect.base import EntityLabel
+from redactor.replace.plan_builder import PlanEntry
+from redactor.verify.scanner import scan_text
+
+
+def _base_cfg() -> ConfigModel:
+    cfg = load_config()
+    cfg.detectors.ner.enabled = False
+    return cfg
+
+
+def test_baseline_detection() -> None:
+    cfg = _base_cfg()
+    text = "Email john@acme.com, Phone +12125550000, SSN 123-45-6789."
+    report = scan_text(text, cfg)
+    assert report.counts_by_label["EMAIL"] == 1
+    assert report.counts_by_label["PHONE"] == 1
+    assert report.counts_by_label["ACCOUNT_ID"] == 1
+    assert report.residual_count == 3
+
+
+def test_replacement_matches_ignored() -> None:
+    cfg = _base_cfg()
+    text = "foo@bar.com\n+12025550100\n123 Main St"
+    plan = [
+        PlanEntry(0, 0, "foo@bar.com", EntityLabel.EMAIL, None, None, {}),
+        PlanEntry(0, 0, "+12025550100", EntityLabel.PHONE, None, None, {}),
+        PlanEntry(0, 0, "123 Main St", EntityLabel.ADDRESS_BLOCK, None, None, {}),
+    ]
+    report = scan_text(text, cfg, applied_plan=plan)
+    assert report.residual_count == 0
+    assert {f.ignored_reason for f in report.ignored} == {"replacement_match"}
+    assert report.ignored_by_label == {"EMAIL": 1, "PHONE": 1, "ADDRESS_BLOCK": 1}
+
+
+def test_policy_keep_roles() -> None:
+    cfg = _base_cfg()
+    cfg.redact.alias_labels = "keep_roles"
+    text = 'Acme LLC (hereinafter "Buyer"). Buyer shall pay.'
+    report = scan_text(text, cfg)
+    assert report.ignored_by_label["ALIAS_LABEL"] >= 1
+    assert all(f.ignored_reason == "policy_keep_roles" for f in report.ignored)
+
+
+def test_policy_generic_dates() -> None:
+    cfg = _base_cfg()
+    text = "Executed on July 4, 1982."
+    report = scan_text(text, cfg)
+    assert report.ignored_by_label["DATE_GENERIC"] == 1
+    cfg.redact.generic_dates = True
+    report2 = scan_text(text, cfg)
+    assert report2.counts_by_label["DATE_GENERIC"] == 1
+
+
+def test_weights_and_scoring() -> None:
+    cfg = load_config()  # keep NER enabled for PERSON detection
+    text = "John Doe john@acme.com 4111-1111-1111-1111 +12125551234"
+    report = scan_text(text, cfg)
+    assert report.counts_by_label == {
+        "PERSON": 1,
+        "EMAIL": 1,
+        "ACCOUNT_ID": 1,
+        "PHONE": 1,
+    }
+    assert report.score == 3 + 3 + 3 + 2
+
+
+def test_confidence_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _base_cfg()
+
+    from redactor.detect.base import EntitySpan
+    from redactor.detect.email import EmailDetector
+
+    def fake_detect(
+        self: EmailDetector, text: str, context: object | None = None
+    ) -> list[EntitySpan]:
+        return [EntitySpan(0, len(text), text, EntityLabel.EMAIL, "fake", 0.1, {})]
+
+    monkeypatch.setattr(EmailDetector, "detect", fake_detect)
+    report = scan_text("john@acme.com", cfg)
+    assert report.total_found == 0
+
+
+def test_sorting_and_details() -> None:
+    cfg = _base_cfg()
+    text = "123-45-6789 and john@acme.com"
+    report = scan_text(text, cfg)
+    starts = [f.start for f in report.findings]
+    assert starts == sorted(starts)
+    assert "weights" in report.details and "min_confidence" in report.details


### PR DESCRIPTION
## Summary
- implement lightweight verification helpers for safe domains, replacement matching, and scoring weights
- add scanner to re-run detectors on redacted text with policy-aware ignore rules and leakage scoring
- document verification workflow and provide unit tests for scanner

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src pytest tests/test_verify_scanner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b425816dc4832592bb72edcdd4a98f