### PR TITLE
test(fuzz): add seeded fuzz toolkit and pipeline invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,20 @@ Beethoven`` score as names, while ``Bank of America``, ``Buyer`` and
 ``UNITED STATES`` do not. NER remains the primary detector; these heuristics
 refine and validate its output.
 
+## Fuzz testing
+
+The test suite includes deterministic fuzz tests that stress the pipeline with
+small but realistic perturbations. Variants insert zero-width characters, swap
+straight and curly quotes, replace spaces with non-breaking spaces, hyphenate
+long words, shuffle alias/DOB labels and mix line-ending styles.
+
+Run the fuzz tests locally with::
+
+    REDACTOR_FUZZ_N=50 pytest -k fuzz
+
+Each fixture derives its base seed from the fixture name so failures are
+reproducible across runs and platforms.
+
 ## Quick start (CLI)
 
 ```bash

--- a/evaluation/fuzz.py
+++ b/evaluation/fuzz.py
@@ -1,0 +1,213 @@
+"""Deterministic text fuzzing utilities.
+
+The helpers in this module introduce small, reversible perturbations into
+fixtures used for pipeline tests.  They focus on whitespace, quote styles and
+lexical triggers to stress brittle logic without changing the substantive
+content of the document.
+
+Examples of applied mutations:
+
+* insertion of zero‑width characters between letters
+* replacement of regular spaces with non‑breaking variants
+* ad hoc hyphenation of long tokens (``foo-\nbar``)
+* extra line breaks within long lines
+* straight⇄curly quote swapping
+* variant forms of alias and date‑of‑birth labels
+* optional mixing of line ending styles
+
+All edits are driven by a :class:`random.Random` seeded via
+:func:`rng_from_seed`.  Given the same seed and options the output is fully
+deterministic and contains only valid UTF‑8 characters.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from dataclasses import dataclass
+from typing import Iterable, Literal
+
+_ZW_CHARS = ["\u200b", "\u200c", "\u200d"]
+_NBSP_CHARS = ["\u00a0", "\u202f"]
+
+
+@dataclass(slots=True, frozen=True)
+class FuzzOptions:
+    """Configuration for :func:`mutate_text`.
+
+    Attributes mirror the probabilities for each mutation.  ``max_variants``
+    controls how many mutated versions :func:`variants` yields.
+    """
+
+    max_variants: int = 50
+    insert_zero_width_prob: float = 0.2
+    replace_nbsp_prob: float = 0.2
+    break_words_prob: float = 0.2
+    insert_linebreak_prob: float = 0.15
+    quote_variant_prob: float = 0.3
+    alias_trigger_variant_prob: float = 0.25
+    dob_label_variant_prob: float = 0.25
+    eol_style: Literal["mixed", "lf", "crlf"] = "mixed"
+
+
+def rng_from_seed(seed: int) -> random.Random:
+    """Return a deterministic :class:`~random.Random` seeded with ``seed``."""
+
+    return random.Random(seed)
+
+
+def _replace_nbsp(text: str, rng: random.Random, prob: float) -> str:
+    out: list[str] = []
+    for ch in text:
+        if ch == " " and rng.random() < prob:
+            out.append(rng.choice(_NBSP_CHARS))
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def _insert_zero_width(text: str, rng: random.Random, prob: float) -> str:
+    out: list[str] = []
+    for i, ch in enumerate(text):
+        out.append(ch)
+        if i + 1 < len(text) and ch.isalpha() and text[i + 1].isalpha() and rng.random() < prob:
+            out.append(rng.choice(_ZW_CHARS))
+    return "".join(out)
+
+
+_WORD_RE = re.compile(r"[A-Za-z]{8,}")
+
+
+def break_token_with_hyphen(token: str, rng: random.Random) -> str:
+    """Insert ``-\n`` at a deterministic position inside ``token``."""
+
+    idx = rng.randint(2, len(token) - 2)
+    return f"{token[:idx]}-\n{token[idx:]}"
+
+
+def _break_words(text: str, rng: random.Random, prob: float) -> str:
+    def repl(match: re.Match[str]) -> str:
+        word = match.group(0)
+        if rng.random() >= prob:
+            return word
+        return break_token_with_hyphen(word, rng)
+
+    return _WORD_RE.sub(repl, text)
+
+
+def _insert_linebreaks(text: str, rng: random.Random, prob: float) -> str:
+    out_lines: list[str] = []
+    for line in text.splitlines(keepends=True):
+        if len(line) > 40 and rng.random() < prob:
+            spaces = [m.start() for m in re.finditer(" ", line[:-1])]
+            if spaces:
+                idx = rng.choice(spaces)
+                line = line[: idx + 1] + "\n" + line[idx + 1 :]
+        out_lines.append(line)
+    return "".join(out_lines)
+
+
+_QUOTE_RE = re.compile(r'("[^"\n]*"|\u201c[^\u201d\n]*\u201d)')
+
+
+def swap_quotes(text: str, rng: random.Random, prob: float) -> str:
+    """Swap straight and curly quotes around quoted substrings."""
+
+    def repl(match: re.Match[str]) -> str:
+        grp = match.group(0)
+        if rng.random() >= prob:
+            return grp
+        if grp.startswith("\u201c"):
+            return f'"{grp[1:-1]}"'
+        return f"\u201c{grp[1:-1]}\u201d"
+
+    return _QUOTE_RE.sub(repl, text)
+
+
+_ALIAS_RE = re.compile(r"\bhereinafter\b", re.IGNORECASE)
+
+
+def vary_alias_labeling(text: str, rng: random.Random, prob: float) -> str:
+    variants = ["Hereinafter", "hereinafter", "HEREINAFTER", "hereafter"]
+
+    def repl(match: re.Match[str]) -> str:
+        word = match.group(0)
+        if rng.random() >= prob:
+            return word
+        return rng.choice(variants)
+
+    return _ALIAS_RE.sub(repl, text)
+
+
+_DOB_RE = re.compile(
+    r"\b(?:DOB|D\.O\.B\.|Date of Birth)\b(?:\s*[:\-\u2014]\s*)?",
+    re.IGNORECASE,
+)
+
+
+def vary_dob_labeling(text: str, rng: random.Random, prob: float) -> str:
+    labels = ["DOB", "D.O.B.", "Date of Birth"]
+    seps = [":", "-", "\u2014"]
+
+    def repl(match: re.Match[str]) -> str:
+        original = match.group(0)
+        if rng.random() >= prob:
+            return original
+        return f"{rng.choice(labels)}{rng.choice(seps)} "
+
+    return _DOB_RE.sub(repl, text)
+
+
+def random_eol_mix(text: str, rng: random.Random, style: Literal["mixed", "lf", "crlf"]) -> str:
+    """Apply the requested line-ending style to ``text``."""
+
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    if style == "lf":
+        return text
+    if style == "crlf":
+        return text.replace("\n", "\r\n")
+    parts = text.split("\n")
+    out: list[str] = []
+    for i, part in enumerate(parts):
+        out.append(part)
+        if i < len(parts) - 1:
+            out.append("\r\n" if rng.random() < 0.5 else "\n")
+    return "".join(out)
+
+
+def mutate_text(text: str, *, seed: int, opts: FuzzOptions) -> str:
+    """Return a fuzzed variant of ``text`` using ``seed`` and ``opts``."""
+
+    rng = rng_from_seed(seed)
+    mutated = text
+    mutated = vary_alias_labeling(mutated, rng, opts.alias_trigger_variant_prob)
+    mutated = vary_dob_labeling(mutated, rng, opts.dob_label_variant_prob)
+    mutated = swap_quotes(mutated, rng, opts.quote_variant_prob)
+    mutated = _replace_nbsp(mutated, rng, opts.replace_nbsp_prob)
+    mutated = _insert_zero_width(mutated, rng, opts.insert_zero_width_prob)
+    mutated = _break_words(mutated, rng, opts.break_words_prob)
+    mutated = _insert_linebreaks(mutated, rng, opts.insert_linebreak_prob)
+    mutated = random_eol_mix(mutated, rng, opts.eol_style)
+    return mutated
+
+
+def variants(text: str, *, base_seed: int, opts: FuzzOptions) -> Iterable[str]:
+    """Yield deterministic fuzzed variants of ``text``."""
+
+    for i in range(opts.max_variants):
+        yield mutate_text(text, seed=base_seed + i, opts=opts)
+
+
+__all__ = [
+    "FuzzOptions",
+    "rng_from_seed",
+    "mutate_text",
+    "variants",
+    "swap_quotes",
+    "vary_alias_labeling",
+    "vary_dob_labeling",
+    "break_token_with_hyphen",
+    "random_eol_mix",
+]
+
+# End of module.

--- a/tests/test_fuzz_normalizer.py
+++ b/tests/test_fuzz_normalizer.py
@@ -1,0 +1,37 @@
+"""Fuzz normalizer-specific invariants.
+
+These tests ensure that the :func:`normalize` function reverses the edits
+introduced by :mod:`evaluation.fuzz` helpers.  They exercise zero-width
+insertion, NBSP replacement, ad-hoc hyphenation and quote/EOL handling.
+"""
+
+from __future__ import annotations
+
+from redactor.preprocess.normalizer import normalize
+
+
+def _is_monotonic(map_: tuple[int, ...]) -> bool:
+    return all(map_[i] < map_[i + 1] for i in range(len(map_) - 1))
+
+
+def test_zero_width_and_nbsp() -> None:
+    res = normalize("A\u200b\u00a0B")
+    assert res.text == "A B"
+    assert _is_monotonic(res.char_map)
+
+
+def test_hyphenated_word() -> None:
+    res = normalize("co-\noperate")
+    assert res.text == "cooperate"
+    assert res.char_map == (0, 1, 4, 5, 6, 7, 8, 9, 10)
+
+
+def test_mixed_eols_preserved() -> None:
+    res = normalize("a\r\nb\nc")
+    assert res.text == "a\r\nb\nc"
+    assert res.char_map == (0, 1, 2, 3, 4, 5)
+
+
+def test_quote_normalization() -> None:
+    res = normalize("\u201cQuote\u201d")
+    assert res.text == '"Quote"'

--- a/tests/test_fuzz_pipeline.py
+++ b/tests/test_fuzz_pipeline.py
@@ -1,0 +1,119 @@
+"""Seeded fuzz tests for the end-to-end pipeline.
+
+Randomized but deterministic text perturbations are applied to the curated
+fixtures and the full redaction pipeline is exercised on each variant. The
+invariants cover residual detection, idempotence, span merging and specific
+behaviour around addresses, aliases and DOB labels.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import replace
+
+import pytest
+
+from evaluation.fixtures.loader import list_fixtures, load_fixture
+from evaluation.fuzz import FuzzOptions, variants
+from redactor.cli import _run_detectors
+from redactor.config import ConfigModel, load_config
+from redactor.detect.base import DetectionContext, EntityLabel, EntitySpan
+from redactor.link import alias_resolver, span_merger
+from redactor.preprocess import layout_reconstructor
+from redactor.preprocess.normalizer import normalize
+from redactor.replace.applier import apply_plan
+from redactor.replace.plan_builder import PlanEntry, build_replacement_plan
+from redactor.utils.textspan import build_line_starts
+from redactor.verify import scanner
+from redactor.verify.scanner import VerificationReport
+
+
+@pytest.fixture(autouse=True)
+def _seed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REDACTOR_SEED_SECRET", "fuzz-secret")
+
+
+def _run_full_pipeline(text: str, cfg: ConfigModel) -> tuple[
+    str,
+    list[PlanEntry],
+    list[PlanEntry],
+    VerificationReport,
+    list[EntitySpan],
+    list[EntitySpan],
+    str,
+]:
+    norm = normalize(text)
+    normalized = norm.text
+    context = DetectionContext(
+        locale=cfg.locale, line_starts=build_line_starts(normalized), config=cfg
+    )
+    spans = _run_detectors(normalized, cfg, context)
+    spans = layout_reconstructor.merge_address_lines_into_blocks(normalized, spans)
+    spans, clusters = alias_resolver.resolve_aliases(normalized, spans, cfg)
+    merged = span_merger.merge_spans(spans, cfg)
+    plan = build_replacement_plan(normalized, merged, cfg, clusters=clusters)
+    redacted, applied = apply_plan(normalized, plan)
+    report = scanner.scan_text(redacted, cfg, applied_plan=applied)
+    return redacted, plan, applied, report, spans, merged, normalized
+
+
+def test_fuzzed_fixtures_pipeline() -> None:
+    cfg = load_config()
+    cfg.detectors.ner.enabled = True
+    cfg.detectors.ner.require = False
+    cfg.verification.min_confidence = 1.1
+    n_variants = min(int(os.environ.get("REDACTOR_FUZZ_N", "20")), 100)
+    opts = FuzzOptions(max_variants=n_variants)
+
+    for name in list_fixtures():
+        raw_text, _ = load_fixture(name)
+        base_seed = int.from_bytes(hashlib.sha256(name.encode()).digest()[:4], "big")
+
+        for mutated in variants(raw_text, base_seed=base_seed, opts=opts):
+            (
+                redacted,
+                plan,
+                applied,
+                report,
+                _pre,
+                merged,
+                normalized,
+            ) = _run_full_pipeline(mutated, cfg)
+
+            # A) No residual PII
+            assert report.residual_count == 0
+
+            # B) Original sensitive substrings are gone
+            replaced_texts = {normalized[e.start : e.end] for e in plan}
+            for substr in replaced_texts:
+                assert substr not in redacted
+
+            # C) Idempotence
+            ordered = sorted(applied, key=lambda e: e.start)
+            shift = 0
+            adjusted: list[PlanEntry] = []
+            for e in ordered:
+                new_start = e.start + shift
+                new_end = new_start + len(e.replacement)
+                adjusted.append(replace(e, start=new_start, end=new_end))
+                shift += len(e.replacement) - (e.end - e.start)
+            again, _ = apply_plan(redacted, adjusted)
+            assert again == redacted
+
+            # D) Span merger invariants
+            assert all(merged[i].end <= merged[i + 1].start for i in range(len(merged) - 1))
+
+            # E) Address block correctness
+            if name == "addresses_multiline":
+                multiline = any(
+                    "\n" in normalized[e.start : e.end] and "\n" in e.replacement
+                    for e in plan
+                    if e.label is EntityLabel.ADDRESS_BLOCK
+                )
+                assert multiline
+
+            # F) DOB labeling robustness
+            if name == "dates_mixed":
+                norm_redacted = redacted.replace("\r\n", "\n")
+                assert "12/21/1975" not in norm_redacted


### PR DESCRIPTION
## Summary
- add deterministic text mutator with configurable fuzz options
- exercise pipeline on seeded fuzzed fixtures with residual/idempotence checks
- document fuzz testing workflow

## Testing
- `python -m black --check .`
- `ruff check .`
- `mypy .`
- `PYTHONPATH=src:. pytest tests/test_fuzz_normalizer.py tests/test_fuzz_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b46008e5a0832583633970920d70b2