### PR TITLE
feat: cache usaddress parsing with prefilter

### DIFF
--- a/tests/test_detect_address_line.py
+++ b/tests/test_detect_address_line.py
@@ -111,3 +111,23 @@ def test_multiple_lines_order(det: AddressLineDetector) -> None:
 )
 def test_negatives(det: AddressLineDetector, text: str) -> None:
     assert det.detect(text) == []
+
+
+def test_unit_keyword_without_digits(det: AddressLineDetector) -> None:
+    text = "Suite A"
+    span = det.detect(text)[0]
+    assert cast(str, span.attrs["line_kind"]) == "unit"
+    comps = cast(dict[str, str], span.attrs["components"])
+    assert comps.get("OccupancyType") == "Suite"
+    assert comps.get("OccupancyIdentifier") == "A"
+
+
+def test_po_box_prefilter(det: AddressLineDetector) -> None:
+    text = "PO Box 123"
+    span = det.detect(text)[0]
+    assert cast(str, span.attrs["line_kind"]) == "po_box"
+
+
+@pytest.mark.parametrize("text", ["Bank of Example, N.A.", "Main Street"])
+def test_prefilter_non_addresses(det: AddressLineDetector, text: str) -> None:
+    assert det.detect(text) == []


### PR DESCRIPTION
## Summary
- add LRU-cached wrapper around usaddress.parse
- prefilter non-address lines with conservative regexes
- sanitize parsed tokens to preserve previous behavior
- extend address line detector tests for new cases

## Testing
- `pip install -e .` (failed: Could not find a version that satisfies the requirement setuptools)
- `ruff check src/redactor/detect/address_libpostal.py tests/test_detect_address_line.py`
- `black --check src/redactor/detect/address_libpostal.py tests/test_detect_address_line.py`
- `mypy src/redactor/detect/address_libpostal.py tests/test_detect_address_line.py`
- `PYTHONPATH=src pytest tests/test_detect_address_line.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b58ae2f8a483259f3bf4a876491de2