### PR TITLE
Add detector budget and pipeline performance smoke tests

### DIFF
--- a/evaluation/perf.py
+++ b/evaluation/perf.py
@@ -165,5 +165,6 @@ if __name__ == "__main__":  # pragma: no cover - convenience wrapper
     for item in out:
         total_ms = item["stages"]["total"] * 1000.0  # type: ignore[index]
         print(
-            f"{item['name']:<20} {item['chars']:>6} {item['repeat']:>6} {str(item['ner']):>3} {total_ms:>9.1f}"
+            f"{item['name']:<20} {item['chars']:>6} {item['repeat']:>6} "
+            f"{str(item['ner']):>3} {total_ms:>9.1f}"
         )

--- a/src/redactor/detect/ner_spacy.py
+++ b/src/redactor/detect/ner_spacy.py
@@ -22,9 +22,9 @@ from __future__ import annotations
 
 import re
 
-from ..utils.constants import rtrim_index
 from redactor.config import ConfigModel
 
+from ..utils.constants import rtrim_index
 from .base import DetectionContext, EntityLabel, EntitySpan
 from .names_person import score_person_name
 

--- a/src/redactor/detect/phone.py
+++ b/src/redactor/detect/phone.py
@@ -28,10 +28,6 @@ from __future__ import annotations
 import re
 from typing import cast
 
-from ..utils.constants import rtrim_index
-
-from ..utils.constants import rtrim_index
-
 from phonenumbers import (
     SUPPORTED_REGIONS,
     Leniency,
@@ -46,6 +42,7 @@ from phonenumbers import (
     region_code_for_number,
 )
 
+from ..utils.constants import rtrim_index
 from .base import DetectionContext, EntityLabel, EntitySpan
 
 __all__ = ["PhoneDetector", "get_detector"]

--- a/tests/test_perf_detector_budget.py
+++ b/tests/test_perf_detector_budget.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from evaluation.fixtures import loader as fixtures_loader
+from redactor.config import load_config
+from redactor.detect.account_ids import AccountIdDetector
+from redactor.detect.address_libpostal import AddressLineDetector
+from redactor.detect.aliases import AliasDetector
+from redactor.detect.bank_org import BankOrgDetector
+from redactor.detect.base import DetectionContext, Detector
+from redactor.detect.date_dob import DOBDetector
+from redactor.detect.date_generic import DateGenericDetector
+from redactor.detect.email import EmailDetector
+from redactor.detect.phone import PhoneDetector
+from redactor.utils.textspan import build_line_starts
+
+if os.getenv("SKIP_PERF_TESTS") == "1":
+    pytest.skip("Performance tests skipped by SKIP_PERF_TESTS", allow_module_level=True)
+
+
+def _get_env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, "").strip() or default)
+    except ValueError:
+        return default
+
+
+def _get_env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, "").strip() or default)
+    except ValueError:
+        return default
+
+
+def _synth_text(names: list[str], repeat: int) -> str:
+    parts = [fixtures_loader.load_fixture(n)[0] for n in names]
+    base = "\n\n".join(parts)
+    return "\n\n".join([base] * repeat)
+
+
+def test_detector_budget() -> None:
+    repeat = _get_env_int("PERF_REPEAT", 120)
+    text = _synth_text(["banks_ids", "emails_phones"], repeat)
+
+    cfg = load_config()
+    cfg = cfg.model_copy(
+        update={
+            "detectors": cfg.detectors.model_copy(
+                update={
+                    "ner": cfg.detectors.ner.model_copy(
+                        update={"enabled": False, "require": False}
+                    ),
+                    "coref": cfg.detectors.coref.model_copy(
+                        update={
+                            "enabled": False,
+                            "backend": "regex",
+                            "require": False,
+                        }
+                    ),
+                }
+            )
+        }
+    )
+    context = DetectionContext(locale=cfg.locale, line_starts=build_line_starts(text), config=cfg)
+
+    detectors: list[Detector] = [
+        EmailDetector(),
+        PhoneDetector(),
+        AccountIdDetector(),
+        BankOrgDetector(),
+        AddressLineDetector(),
+        DateGenericDetector(),
+        DOBDetector(),
+        AliasDetector(),
+    ]
+    budget = _get_env_float("PERF_MAX_SEC_DET", 1.5)
+
+    for det in detectors:
+        start = time.perf_counter()
+        det.detect(text, context)
+        elapsed = time.perf_counter() - start
+        assert (
+            elapsed <= budget
+        ), f"{det.__class__.__name__} took {elapsed:.3f}s (budget {budget:.3f}s)"

--- a/tests/test_perf_smoke.py
+++ b/tests/test_perf_smoke.py
@@ -1,8 +1,36 @@
 from __future__ import annotations
 
+import os
+from typing import cast
+
+import pytest
+
+from evaluation.fixtures import loader as fixtures_loader
 from evaluation.perf import profile_fixtures, profile_pipeline
 from redactor.config import load_config
-from typing import cast
+
+if os.getenv("SKIP_PERF_TESTS") == "1":
+    pytest.skip("Performance tests skipped by SKIP_PERF_TESTS", allow_module_level=True)
+
+
+def _get_env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, "").strip() or default)
+    except ValueError:
+        return default
+
+
+def _get_env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, "").strip() or default)
+    except ValueError:
+        return default
+
+
+def _synth_text(names: list[str], repeat: int) -> str:
+    parts = [fixtures_loader.load_fixture(n)[0] for n in names]
+    base = "\n\n".join(parts)
+    return "\n\n".join([base] * repeat)
 
 
 def _required_keys() -> set[str]:
@@ -43,3 +71,37 @@ def test_profile_fixtures_smoke() -> None:
     for value in stages.values():
         assert isinstance(value, float)
         assert value >= 0.0
+
+
+def test_profile_pipeline_budget() -> None:
+    repeat = _get_env_int("PERF_REPEAT", 80)
+    text = _synth_text(["banks_ids", "emails_phones"], repeat)
+    cfg = load_config()
+    cfg = cfg.model_copy(
+        update={
+            "detectors": cfg.detectors.model_copy(
+                update={
+                    "ner": cfg.detectors.ner.model_copy(
+                        update={"enabled": False, "require": False}
+                    ),
+                    "coref": cfg.detectors.coref.model_copy(
+                        update={
+                            "enabled": False,
+                            "backend": "regex",
+                            "require": False,
+                        }
+                    ),
+                }
+            )
+        }
+    )
+    stages = profile_pipeline(text, cfg)
+    budget = _get_env_float("PERF_MAX_SEC", 5.0)
+    assert (
+        stages["total"] <= budget
+    ), f"pipeline total {stages['total']:.3f}s (budget {budget:.3f}s)"
+    assert set(stages) == _required_keys()
+    for key in ["detect", "plan_build", "apply"]:
+        assert stages[key] >= 0.0
+    subtotal = sum(v for k, v in stages.items() if k != "total")
+    assert stages["total"] >= subtotal - 0.001


### PR DESCRIPTION
## Summary
- add synthetic detector budget test with configurable env thresholds
- extend performance smoke tests with pipeline timing budget and helpers
- fix import ordering and wrap long lines for linting

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest tests/test_perf_detector_budget.py -q`
- `pytest tests/test_perf_smoke.py -q`
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools)*
- `pytest -q` *(fails: numerous tests fail when run against this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b5917255f8832585ccfde55571919b