### PR TITLE
chore(build): add build sanity test

### DIFF
--- a/evaluation/build_readme_check.py
+++ b/evaluation/build_readme_check.py
@@ -1,0 +1,29 @@
+import tomllib
+from pathlib import Path
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    pyproject_path = root / "pyproject.toml"
+    with pyproject_path.open("rb") as f:
+        pyproject = tomllib.load(f)
+
+    readme = pyproject.get("project", {}).get("readme")
+    if isinstance(readme, dict):
+        readme_path = root / readme.get("file", "")
+    elif isinstance(readme, str):
+        readme_path = root / readme
+    else:
+        readme_path = None
+
+    print(f"pyproject readme: {readme}")
+    if readme_path is not None:
+        print(f"resolved path: {readme_path}")
+        print(f"exists: {readme_path.exists()}")
+    else:
+        print("resolved path: None")
+        print("exists: False")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "mypy>=1.7",
     "pytest>=7.4",
     "pytest-cov>=4.1",
+    "build>=1.2.1",
 ]
 ner = ["spacy>=3.7,<3.8"]
 coref = ["fastcoref>=2.1.6", "torch>=2.0"]

--- a/tests/test_build_sanity.py
+++ b/tests/test_build_sanity.py
@@ -1,0 +1,72 @@
+import subprocess
+import sys
+import tarfile
+import tomllib
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+with (ROOT / "pyproject.toml").open("rb") as f:
+    pyproject = tomllib.load(f)
+project_name = pyproject["project"]["name"]
+has_readme = "readme" in pyproject["project"]
+
+try:  # pragma: no cover - import guard
+    import build  # type: ignore[import-not-found]  # noqa: F401
+except Exception:  # pragma: no cover - module not installed
+    pytest.skip("build package is required for this test", allow_module_level=True)
+
+
+def test_build_sanity() -> None:
+    with TemporaryDirectory() as tmpdir:
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "build",
+                "--sdist",
+                "--wheel",
+                "--outdir",
+                tmpdir,
+            ],
+            check=True,
+            cwd=str(ROOT),
+            capture_output=True,
+        )
+
+        tmp_path = Path(tmpdir)
+        wheels = list(tmp_path.glob("*.whl"))
+        sdists = list(tmp_path.glob("*.tar.gz"))
+        assert len(wheels) == 1
+        assert len(sdists) == 1
+
+        wheel_path = wheels[0]
+        with zipfile.ZipFile(wheel_path) as zf:
+            metadata_files = [n for n in zf.namelist() if n.endswith(".dist-info/METADATA")]
+            assert metadata_files, "METADATA not found in wheel"
+            metadata_text = zf.read(metadata_files[0]).decode()
+            lines = metadata_text.splitlines()
+            assert f"Name: {project_name}" in lines
+            version_line = next((line for line in lines if line.startswith("Version:")), "")
+            assert version_line.split(":", 1)[1].strip()
+            summary_line = next((line for line in lines if line.startswith("Summary:")), "")
+            assert summary_line
+            summary_value = summary_line.split(":", 1)[1].strip()
+            assert summary_value or not has_readme
+            classifiers = [line for line in lines if line.startswith("Classifier:")]
+            assert classifiers
+
+            entry_files = [n for n in zf.namelist() if n.endswith(".dist-info/entry_points.txt")]
+            assert entry_files, "entry_points.txt not found"
+            entry_text = zf.read(entry_files[0]).decode()
+            assert "[console_scripts]" in entry_text
+            assert "redactor = redactor.cli:app" in entry_text
+
+        sdist_path = sdists[0]
+        with tarfile.open(sdist_path) as tf:
+            names = tf.getnames()
+            assert any(name.endswith("pyproject.toml") for name in names)
+            assert any(name.endswith("src/redactor/__init__.py") for name in names)


### PR DESCRIPTION
## Summary
- verify project metadata and console script via local sdist/wheel build
- include `build` package in dev extras for local builds
- add helper to check that `pyproject.toml` references an existing README

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src:. pytest tests/test_build_sanity.py -vv` *(skipped: build package is required for this test)*
- `PYTHONPATH=src:. pytest -q` *(fails: 20 tests failed)*


------
https://chatgpt.com/codex/tasks/task_e_68b595f29e2c8325a8ed5815f176efb1