### PR TITLE
Add minimal Python 3.11 CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'README.md'
+      - '.github/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'README.md'
+      - '.github/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      SKIP_PERF_TESTS: '1'
+      PYTHONWARNINGS: default
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-3.11-${{ hashFiles('pyproject.toml') }}
+      - name: Install dependencies
+        run: pip install -e .[dev]
+      - name: Ruff
+        run: ruff check .
+      - name: Black
+        run: black --check .
+      - name: Mypy
+        run: mypy .
+      - name: Pytest
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The redactor project aims to provide a privacy-first pipeline for sanitizing legal documents before they are shared with cloud-based language models. It replaces sensitive personal and organizational information with deterministic pseudonyms while preserving the technical facts necessary for analysis. The system operates entirely offline by default and relies on open-source tools for detection and replacement of PII. Each modification is auditable so users can trace the origin and rationale for every change. The goal is to ensure zero leakage of personal data, reproducible outputs, and seamless integration into legal workflows. This repository currently contains only the foundational scaffolding; product functionality will be added in future iterations.
 
+## Continuous integration
+
+A GitHub Actions workflow runs Ruff, Black in check mode, mypy, and pytest on Python 3.11. Performance tests are skipped in CI via `SKIP_PERF_TESTS=1`.
+
 ## Install extras
 
 Optional extras let you pull in only the dependencies you need:


### PR DESCRIPTION
## Summary
- add GitHub Actions CI running ruff, black --check, mypy, and pytest on Python 3.11
- cache pip and skip perf tests via SKIP_PERF_TESTS=1
- document CI workflow in README

## Testing
- `ruff check .`
- `black --check .`
- `PYTHONPATH=src:. mypy .`
- `PYTHONPATH=src:. pytest -q` *(fails: assert 6 == 0, failing detector tests)*
- `pre-commit run --files README.md .github/workflows/ci.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5987d12f883259130fe6740c64484