### PR TITLE
Add minimal CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'README.md'
+      - '.github/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'README.md'
+      - '.github/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      SKIP_PERF_TESTS: '1'
+      PYTHONWARNINGS: default
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-3.11-${{ hashFiles('pyproject.toml') }}
+      - run: pip install -e .[dev]
+      - run: |
+          ruff check .
+          black --check .
+          mypy .
+          pytest -q

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ NER and coreference resolution are disabled by default and require installing
 their respective extras. The base install already includes phone number and
 account detectors.
 
+## CI
+
+The project uses GitHub Actions to run linting, formatting checks, type
+checking and tests on Python 3.11. Performance tests are skipped in CI by
+default by setting `SKIP_PERF_TESTS=1`.
+
 ## Architecture at a glance
 
 ### Top-level modules


### PR DESCRIPTION
## Summary
- run ruff, black --check, mypy and pytest on Python 3.11
- document CI setup and default skipping of performance tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src:. pytest -q` *(fails: assert 6 == 0, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b59d06340883258fa403c30cccc2cf