### PR TITLE
Add minimal CI workflow and skip missing build tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "src/"
+      - "tests/"
+      - "pyproject.toml"
+      - "README.md"
+      - ".github/**"
+  push:
+    branches: [ main ]
+    paths:
+      - "src/"
+      - "tests/"
+      - "pyproject.toml"
+      - "README.md"
+      - ".github/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      SKIP_PERF_TESTS: 1
+      PYTHONWARNINGS: default
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run checks
+        run: |
+          ruff check .
+          black --check .
+          mypy .
+          pytest -q

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The redactor project aims to provide a privacy-first pipeline for sanitizing legal documents before they are shared with cloud-based language models. It replaces sensitive personal and organizational information with deterministic pseudonyms while preserving the technical facts necessary for analysis. The system operates entirely offline by default and relies on open-source tools for detection and replacement of PII. Each modification is auditable so users can trace the origin and rationale for every change. The goal is to ensure zero leakage of personal data, reproducible outputs, and seamless integration into legal workflows. This repository currently contains only the foundational scaffolding; product functionality will be added in future iterations.
 
+## Continuous Integration
+
+Pull requests targeting `main` run linting, formatting, type checking, and the test suite. The same workflow also runs for pushes to `main`.
+
 ## Install extras
 
 Optional extras let you pull in only the dependencies you need:

--- a/tests/test_build_sanity.py
+++ b/tests/test_build_sanity.py
@@ -8,16 +8,13 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
+pytest.importorskip("build", reason="'build' extra not installed")
+
 ROOT = Path(__file__).resolve().parents[1]
 with (ROOT / "pyproject.toml").open("rb") as f:
     pyproject = tomllib.load(f)
 project_name = pyproject["project"]["name"]
 has_readme = "readme" in pyproject["project"]
-
-try:  # pragma: no cover - import guard
-    import build  # type: ignore[import-not-found]  # noqa: F401
-except Exception:  # pragma: no cover - module not installed
-    pytest.skip("build package is required for this test", allow_module_level=True)
 
 
 def test_build_sanity() -> None:


### PR DESCRIPTION
## Summary
- run a single Python 3.11 CI job on pull requests to `main` with lint, type checking, formatting and tests
- document CI behavior in the README
- ensure build-sanity test skips if `build` isn't installed

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src python -m pytest -q` *(fails: assert 6 == 0, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b5aa3fc5c8832591cf877c71c3b3e3