### PR TITLE
Add minimal CI workflow for tests with address support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      SKIP_PERF_TESTS: 1
+      PYTHONPATH: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - run: pip install -e .[dev,addresses]
+      - run: |
+          ruff check .
+          black --check .
+          mypy .
+          pytest -q

--- a/tests/test_build_sanity.py
+++ b/tests/test_build_sanity.py
@@ -8,16 +8,13 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
+pytest.importorskip("build", reason="'build' extra not installed")
+
 ROOT = Path(__file__).resolve().parents[1]
 with (ROOT / "pyproject.toml").open("rb") as f:
     pyproject = tomllib.load(f)
 project_name = pyproject["project"]["name"]
 has_readme = "readme" in pyproject["project"]
-
-try:  # pragma: no cover - import guard
-    import build  # type: ignore[import-not-found]  # noqa: F401
-except Exception:  # pragma: no cover - module not installed
-    pytest.skip("build package is required for this test", allow_module_level=True)
 
 
 def test_build_sanity() -> None:

--- a/tests/test_detect_address_line.py
+++ b/tests/test_detect_address_line.py
@@ -4,6 +4,8 @@ from typing import cast
 
 import pytest
 
+pytest.importorskip("usaddress", reason="addresses extra not installed")
+
 from redactor.detect.address_libpostal import AddressLineDetector
 from redactor.detect.base import EntityLabel, EntitySpan
 


### PR DESCRIPTION
## Summary
- run linting and tests in CI with dev and addresses extras
- skip build and usaddress-dependent tests when extras missing

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'usaddress')*


------
https://chatgpt.com/codex/tasks/task_e_68b5ae77612483259ac92e8fc0b7c00b