### PR TITLE
Expand CI matrix and upload coverage artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "src/"
+      - "tests/"
+      - "pyproject.toml"
+      - "README.md"
+      - ".github/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python: ["3.11", "3.12"]
+    env:
+      SKIP_PERF_TESTS: 1
+      PYTHONWARNINGS: default
+      PYTHONPATH: ${{ github.workspace }}
+      NO_COLOR: 1
+      RICH_DISABLE_NO_COLOR: 1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ${{ runner.os == 'Windows' && 'C:\\Users\\runneradmin\\AppData\\Local\\pip\\Cache' || '~/.cache/pip' }}
+          key: pip-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            pip-${{ runner.os }}-
+      - name: Install dependencies
+        run: pip install -e .[dev,addresses]
+      - name: Ruff
+        run: ruff check .
+      - name: Black
+        run: black --check .
+      - name: Mypy
+        run: mypy .
+      - name: Pytest
+        run: pytest -q --cov=redactor --cov-report=xml
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}-${{ matrix.python }}
+          path: coverage.xml
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: report-${{ matrix.os }}-${{ matrix.python }}
+          path: report/
+          if-no-files-found: ignore

--- a/tests/test_build_sanity.py
+++ b/tests/test_build_sanity.py
@@ -8,16 +8,13 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
+pytest.importorskip("build")
+
 ROOT = Path(__file__).resolve().parents[1]
 with (ROOT / "pyproject.toml").open("rb") as f:
     pyproject = tomllib.load(f)
 project_name = pyproject["project"]["name"]
 has_readme = "readme" in pyproject["project"]
-
-try:  # pragma: no cover - import guard
-    import build  # type: ignore[import-not-found]  # noqa: F401
-except Exception:  # pragma: no cover - module not installed
-    pytest.skip("build package is required for this test", allow_module_level=True)
 
 
 def test_build_sanity() -> None:


### PR DESCRIPTION
## Summary
- run CI on Ubuntu and Windows for Python 3.11 and 3.12
- harden environment and cache pip, running lint, type checking, tests and uploading coverage
- skip build sanity test when `build` is not installed

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q --cov=redactor --cov-report=xml` *(fails: plugin/coverage dependencies missing)*


------
https://chatgpt.com/codex/tasks/task_e_68b5dcf2485483259537621ac9a8b264