### PR TITLE
fix(ci-stability): CLI help plain flags; restore phone detection; disambiguate ABA vs EIN; suffix-aware bank trimming; correct alias subject fields; support DOB em/en dashes; scanner ignores address replacement lines

### DIFF
--- a/src/redactor/detect/aliases.py
+++ b/src/redactor/detect/aliases.py
@@ -123,7 +123,7 @@ def _is_title_token(token: str) -> bool:
 
 
 def _looks_like_subject(text: str) -> bool:
-    if re.search(r"\b(LLC|Inc\.?|Ltd\.?|N\.A\.)\b", text):
+    if re.search(r"\b(LLC|Inc\.?|Ltd\.?|N\.A\.|Bank|Trust|Company)\b", text):
         return True
     words = text.split()
     for i in range(len(words) - 1):
@@ -139,17 +139,14 @@ def _guess_subject(
         line_no = find_line_for_char(start, line_index)
     except ValueError:
         return None, None
-    looked = 0
     prev = line_no - 1
-    while prev >= 0 and looked < 2:
+    while prev >= 0:
         l_start, l_end, _ = line_index[prev]
         candidate = text[l_start:l_end].strip()
-        if candidate:
-            looked += 1
-            if _looks_like_subject(candidate):
-                # TODO(M7-T2): prefer name-like candidates using
-                # ``is_probable_person_name`` from ``names_person``.
-                return candidate, prev
+        if candidate and _looks_like_subject(candidate):
+            # TODO(M7-T2): prefer name-like candidates using
+            # ``is_probable_person_name`` from ``names_person``.
+            return candidate, prev
         prev -= 1
     return None, None
 

--- a/src/redactor/detect/phone.py
+++ b/src/redactor/detect/phone.py
@@ -42,7 +42,7 @@ from phonenumbers import (
     region_code_for_number,
 )
 
-from ..utils.constants import rtrim_index
+from ..utils.constants import RIGHT_TRIM
 from .base import DetectionContext, EntityLabel, EntitySpan
 
 __all__ = ["PhoneDetector", "get_detector"]
@@ -139,7 +139,8 @@ class PhoneDetector:
             if not is_valid_number(num):
                 continue
 
-            end = rtrim_index(text, end)
+            if end > start and text[end - 1] in RIGHT_TRIM:
+                end -= 1
             matched_text = text[start:end]
 
             attrs: dict[str, object] = {


### PR DESCRIPTION
## Summary
- ensure plain CLI help with `--in/--out` aliases and no rich formatting when not attached to a TTY
- restore phone detection via `PhoneNumberMatcher` with single-char punctuation trimming
- tighten account ID logic for ABA routing vs EIN and switch SWIFT check to `stdnum.bic`
- refine bank/org trimming to keep corporate suffix dots and drop trailing prose punctuation
- improve alias subject handling and DOB triggers; verification scanner now ignores replacement address lines

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src:. pytest tests/test_cli_help.py tests/test_detect_phone.py tests/test_detect_account_ids.py::test_true_positive_aba_with_context tests/test_detect_account_ids.py::test_negatives[021000021] tests/test_detect_bank_org.py tests/test_detect_aliases.py::test_hereinafter_prev_line_guess tests/test_detect_aliases.py::test_role_alias tests/test_detect_dates.py::test_multiple_dates -q`
- `PYTHONPATH=src:. pytest -q` *(fails: address/libpostal dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e43fb04c8325b0e90a423208c298