### PR TITLE
feat(verify): add secret-leak guard to report bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ Use `--require-secret` in CI/automation to fail fast if the secret is missing.
 The secret is never written to audit artifacts; only a `seed_present` boolean
 is recorded.
 
+## Audit artifact safety
+
+The seed is never written to disk; `audit.json` only records a `seed_present`
+flag indicating whether a secret was configured. The report writer also refuses
+to write if a secret-like value would appear in the payloads (for example, if a
+`PlanEntry.meta` accidentally includes configuration or secrets).
+
 ## Pseudonym generator (stub)
 
 The current pseudonym generator maps each entity to a deterministic placeholder

--- a/src/redactor/replace/plan_builder.py
+++ b/src/redactor/replace/plan_builder.py
@@ -258,6 +258,8 @@ def build_replacement_plan(
         if replacement is None:
             continue
 
+        # Never include secrets or cfg values in ``meta``; audit writer will
+        # refuse to write if secret-like values appear.
         meta: dict[str, object] = {
             "source": sp.source,
             "span_id": sp.span_id,


### PR DESCRIPTION
## Summary
- detect presence of seed secret and expose seed_present flag in audit summary
- scan report payloads for secret-like values before writing to disk
- document audit artifact safety and caution against embedding secrets in plan metadata

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src:. pytest tests/test_audit_report.py::test_seed_presence_signal tests/test_audit_report.py::test_secret_leakage_prevention -q`
- `PYTHONPATH=src:. pytest tests/test_cli_full_pipeline.py::test_seed_present_in_audit -q`
- `PYTHONPATH=src:. pytest -q` *(fails: numerous existing tests failing, e.g., address detection and CLI strict verification)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f4a0aa608325a9c044c4a43ba032