### PR TITLE
feat(replace): add safety guard for replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ reverse order so indices remain valid.  Role labels may be preserved when
 ``redact.alias_labels`` is set to ``"keep_roles"`` and generic dates remain
 unless ``redact.generic_dates`` is enabled.
 
+We run a bounded, deterministic safety check during planning to ensure generated emails use example.org, phones use safe 555 patterns, and numeric IDs don't collide with sensitive real values. If a first attempt looks unsafe, we retry with a salted key up to a small bound.
+
 ```text
 Before: John Doe (the "Buyer") was born on July 4, 1982.
 After:  Alan Smith (the "Buyer") was born on May 9, 1960.

--- a/src/redactor/replace/plan_builder.py
+++ b/src/redactor/replace/plan_builder.py
@@ -102,6 +102,160 @@ def _generate_fake_date_like(
     return norm
 
 
+def _normalize_digits(text: str) -> str:
+    """Return ``text`` stripped to digits only."""
+
+    return re.sub(r"\D", "", text)
+
+
+def _luhn_valid(num: str) -> bool:
+    total = 0
+    for idx, ch in enumerate(reversed(num)):
+        digit = int(ch)
+        if idx % 2 == 1:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        total += digit
+    return total % 10 == 0
+
+
+def _aba_check_digit(eight: str) -> str:
+    weights = [3, 7, 1] * 3
+    total = sum(int(d) * w for d, w in zip(eight, weights, strict=False))
+    return str((10 - total % 10) % 10)
+
+
+def _format_digits_like(source: str, digits: str) -> str:
+    """Replace digits in ``source`` with those from ``digits``."""
+
+    it = iter(digits)
+    out: list[str] = []
+    for ch in source:
+        if ch.isdigit():
+            out.append(next(it, "0"))
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def _detect_account_subtype(source: str) -> str:
+    if re.fullmatch(r"\d{2}-\d{7}", source):
+        return "ein"
+    if re.fullmatch(r"\d{3}-\d{2}-\d{4}", source):
+        return "ssn"
+    if re.fullmatch(r"\d{9}", _normalize_digits(source)) and "-" not in source:
+        return "routing_aba"
+    if re.search(r"[A-Za-z]", source):
+        if re.match(r"[A-Za-z]{2}", source):
+            return "iban"
+        return "swift_bic"
+    digits = _normalize_digits(source)
+    if 13 <= len(digits) <= 19:
+        return "cc"
+    return "generic"
+
+
+def _ensure_safe_replacement(
+    label: EntityLabel,
+    source: str,
+    candidate: str,
+    *,
+    key: str,
+    gen: PseudonymGenerator,
+) -> str:
+    """Return a safe replacement value for ``candidate``."""
+
+    for attempt in range(3):
+        if label is EntityLabel.EMAIL:
+            local, _, domain = candidate.partition("@")
+            domain = domain.lower()
+            if not domain.isascii() or domain != "example.org":
+                candidate = f"{local}@example.org"
+                domain = "example.org"
+            if domain == "example.org" and domain.isascii():
+                return candidate
+            token = gen.token("EMAIL", f"{key}:{attempt + 1}", length=10)
+            local = f"u{token}"
+            if "+" in source.split("@", 1)[0]:
+                local = f"{local}+t{token[-3:]}"
+            candidate = f"{local}@example.org"
+            continue
+        if label is EntityLabel.PHONE:
+            digits = _normalize_digits(candidate)
+            if candidate.startswith("+"):
+                if digits.startswith("1555"):
+                    return candidate
+            elif len(digits) >= 10 and digits[3:6] == "555":
+                return candidate
+            rng = gen.rng("SAFE_PHONE", f"{key}:{attempt + 1}")
+            npa = rng.randint(200, 999)
+            line = rng.randint(0, 9999)
+            new_digits = f"{npa:03d}555{line:04d}"
+            if candidate.startswith("+"):
+                new_digits = "1" + new_digits
+                candidate = "+" + _format_digits_like(candidate[1:], new_digits)
+            else:
+                candidate = _format_digits_like(candidate, new_digits)
+            continue
+        if label is EntityLabel.ACCOUNT_ID:
+            subtype = _detect_account_subtype(source)
+            digits = _normalize_digits(candidate)
+            if subtype == "cc":
+                if _luhn_valid(digits):
+                    return candidate
+                candidate = gen.cc_like(source, key=f"{key}:{attempt + 1}")
+                continue
+            if subtype == "routing_aba":
+                if (
+                    len(digits) == 9
+                    and digits != "021000021"
+                    and _aba_check_digit(digits[:8]) == digits[8]
+                ):
+                    return candidate
+                candidate = gen.routing_like(source, key=f"{key}:{attempt + 1}")
+                continue
+            if subtype == "ssn":
+                area = digits[:3]
+                if area not in {"000", "666"} and not area.startswith("9"):
+                    return candidate
+                candidate = gen.ssn_like(source, key=f"{key}:{attempt + 1}")
+                continue
+            if subtype == "ein":
+                if "-" in candidate and digits != _normalize_digits(source):
+                    return candidate
+                candidate = gen.ein_like(source, key=f"{key}:{attempt + 1}")
+                continue
+            if subtype == "iban":
+                if candidate != source:
+                    return candidate
+                candidate = gen.iban_like(source, key=f"{key}:{attempt + 1}")
+                continue
+            if subtype == "swift_bic":
+                if candidate.isascii() and candidate != source:
+                    return candidate
+                candidate = case_preserver.match_case(
+                    source, gen.account_number(f"{key}:{attempt + 1}", kind="bic")
+                )
+                continue
+            if digits != _normalize_digits(source):
+                return candidate
+            candidate = gen.generic_digits_like(source, key=f"{key}:{attempt + 1}")
+            continue
+        if label is EntityLabel.DOB:
+            if _normalize_digits(candidate) != _normalize_digits(source):
+                return candidate
+            candidate = _generate_fake_date_like(
+                source,
+                {"normalized": _normalize_digits(source)},
+                key=f"{key}:{attempt + 1}",
+                gen=gen,
+            )
+            continue
+        return candidate
+    return candidate
+
+
 def build_replacement_plan(
     text: str,
     spans: list[EntitySpan],
@@ -170,6 +324,9 @@ def build_replacement_plan(
                 return f"{local}@example.org"
 
             replacement = _ensure_diff(sp.text, key, build_email)
+            replacement = _ensure_safe_replacement(
+                EntityLabel.EMAIL, sp.text, replacement, key=key, gen=gen
+            )
         elif label is EntityLabel.PHONE:
             key = sp.entity_id or sp.text
 
@@ -177,6 +334,9 @@ def build_replacement_plan(
                 return number_rules.generate_generic_digits_like(text, key=k, gen=gen)
 
             replacement = _ensure_diff(sp.text, key, build_phone)
+            replacement = _ensure_safe_replacement(
+                EntityLabel.PHONE, sp.text, replacement, key=key, gen=gen
+            )
         elif label is EntityLabel.ACCOUNT_ID:
             subtype = cast(str | None, sp.attrs.get("subtype")) or "generic"
             key = sp.entity_id or sp.text
@@ -186,45 +346,69 @@ def build_replacement_plan(
                     return number_rules.generate_cc_like(text, key=k, gen=gen)
 
                 replacement = _ensure_diff(sp.text, key, build_cc)
+                replacement = _ensure_safe_replacement(
+                    EntityLabel.ACCOUNT_ID, sp.text, replacement, key=key, gen=gen
+                )
             elif subtype == "routing_aba":
 
                 def build_routing(k: str, text: str = sp.text) -> str:
                     return number_rules.generate_routing_like(text, key=k, gen=gen)
 
                 replacement = _ensure_diff(sp.text, key, build_routing)
+                replacement = _ensure_safe_replacement(
+                    EntityLabel.ACCOUNT_ID, sp.text, replacement, key=key, gen=gen
+                )
             elif subtype == "iban":
 
                 def build_iban(k: str, text: str = sp.text) -> str:
                     return number_rules.generate_iban_like(text, key=k, gen=gen)
 
                 replacement = _ensure_diff(sp.text, key, build_iban)
+                replacement = _ensure_safe_replacement(
+                    EntityLabel.ACCOUNT_ID, sp.text, replacement, key=key, gen=gen
+                )
             elif subtype == "ssn":
 
                 def build_ssn(k: str, text: str = sp.text) -> str:
                     return number_rules.generate_ssn_like(text, key=k, gen=gen)
 
                 replacement = _ensure_diff(sp.text, key, build_ssn)
+                replacement = _ensure_safe_replacement(
+                    EntityLabel.ACCOUNT_ID, sp.text, replacement, key=key, gen=gen
+                )
             elif subtype == "ein":
 
                 def build_ein(k: str, text: str = sp.text) -> str:
                     return number_rules.generate_ein_like(text, key=k, gen=gen)
 
                 replacement = _ensure_diff(sp.text, key, build_ein)
+                replacement = _ensure_safe_replacement(
+                    EntityLabel.ACCOUNT_ID, sp.text, replacement, key=key, gen=gen
+                )
             elif subtype == "swift_bic":
 
                 def build_bic(k: str, text: str = sp.text) -> str:
                     return case_preserver.match_case(text, gen.account_number(k, kind="bic"))
 
                 replacement = _ensure_diff(sp.text, key, build_bic)
+                replacement = _ensure_safe_replacement(
+                    EntityLabel.ACCOUNT_ID, sp.text, replacement, key=key, gen=gen
+                )
             else:
 
                 def build_generic(k: str, text: str = sp.text) -> str:
                     return number_rules.generate_generic_digits_like(text, key=k, gen=gen)
 
                 replacement = _ensure_diff(sp.text, key, build_generic)
+                replacement = _ensure_safe_replacement(
+                    EntityLabel.ACCOUNT_ID, sp.text, replacement, key=key, gen=gen
+                )
         elif label is EntityLabel.DOB:
             key = sp.entity_id or cast(str | None, sp.attrs.get("normalized")) or sp.text
             replacement = _generate_fake_date_like(sp.text, sp.attrs, key=key, gen=gen)
+            replacement = _ensure_safe_replacement(
+                EntityLabel.DOB, sp.text, replacement, key=key, gen=gen
+            )
         elif label is EntityLabel.DATE_GENERIC:
             if cfg.redact.generic_dates:
                 key = sp.entity_id or cast(str | None, sp.attrs.get("normalized")) or sp.text

--- a/tests/test_replace_safety_guard.py
+++ b/tests/test_replace_safety_guard.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import re
+
+from redactor.config import load_config
+from redactor.detect.base import EntityLabel, EntitySpan
+from redactor.replace import plan_builder
+
+
+def _span(
+    start: int,
+    end: int,
+    text: str,
+    label: EntityLabel,
+    *,
+    attrs: dict[str, object] | None = None,
+) -> EntitySpan:
+    return EntitySpan(start, end, text, label, "test", 0.9, attrs or {})
+
+
+def _luhn_valid(num: str) -> bool:
+    total = 0
+    for idx, ch in enumerate(reversed(num)):
+        digit = int(ch)
+        if idx % 2 == 1:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        total += digit
+    return total % 10 == 0
+
+
+def _aba_check_digit(eight: str) -> str:
+    weights = [3, 7, 1] * 3
+    total = sum(int(d) * w for d, w in zip(eight, weights, strict=False))
+    return str((10 - total % 10) % 10)
+
+
+def test_email_replacement_safe_domain() -> None:
+    cfg = load_config()
+    src = "john@acme.com"
+    text = f"Contact {src}"
+    s = text.index(src)
+    span = _span(s, s + len(src), src, EntityLabel.EMAIL, attrs={"base_local": "john"})
+    plan = plan_builder.build_replacement_plan(text, [span], cfg)
+    repl = plan[0].replacement
+    assert repl.endswith("@example.org")
+    local = repl.split("@", 1)[0].split("+", 1)[0]
+    assert local.lower() != "john"
+
+
+def test_phone_replacement_uses_safe_pattern() -> None:
+    cfg = load_config()
+    src = "(415) 867-5309"
+    text = f"Call {src} now"
+    s = text.index(src)
+    span = _span(s, s + len(src), src, EntityLabel.PHONE)
+    plan = plan_builder.build_replacement_plan(text, [span], cfg)
+    repl = plan[0].replacement
+    for sc, rc in zip(src, repl, strict=True):
+        if not sc.isdigit():
+            assert sc == rc
+    digits = re.sub(r"\D", "", repl)
+    if repl.startswith("+"):
+        assert digits.startswith("1555")
+    else:
+        assert digits[3:6] == "555"
+
+
+def test_account_routing_safe() -> None:
+    cfg = load_config()
+    src = "021000021"
+    text = f"routing {src}"
+    s = text.index(src)
+    span = _span(s, s + len(src), src, EntityLabel.ACCOUNT_ID, attrs={"subtype": "routing_aba"})
+    plan = plan_builder.build_replacement_plan(text, [span], cfg)
+    repl = plan[0].replacement
+    digits = re.sub(r"\D", "", repl)
+    assert digits != src
+    assert len(digits) == 9
+    assert _aba_check_digit(digits[:8]) == digits[8]
+    assert digits != "021000021"
+
+
+def test_account_ein_safe() -> None:
+    cfg = load_config()
+    src = "12-3456789"
+    text = f"ein {src}"
+    s = text.index(src)
+    span = _span(s, s + len(src), src, EntityLabel.ACCOUNT_ID, attrs={"subtype": "ein"})
+    plan = plan_builder.build_replacement_plan(text, [span], cfg)
+    repl = plan[0].replacement
+    assert re.fullmatch(r"\d{2}-\d{7}", repl)
+    assert repl != src
+
+
+def test_account_cc_safe() -> None:
+    cfg = load_config()
+    src = "4111 1111 1111 1111"
+    text = f"cc {src}"
+    s = text.index(src)
+    span = _span(s, s + len(src), src, EntityLabel.ACCOUNT_ID, attrs={"subtype": "cc"})
+    plan = plan_builder.build_replacement_plan(text, [span], cfg)
+    repl = plan[0].replacement
+    digits = re.sub(r"\D", "", repl)
+    assert repl != src
+    assert _luhn_valid(digits)
+
+
+def test_account_generic_safe() -> None:
+    cfg = load_config()
+    src = "000123-456-789"
+    text = f"num {src}"
+    s = text.index(src)
+    span = _span(s, s + len(src), src, EntityLabel.ACCOUNT_ID, attrs={"subtype": "generic"})
+    plan = plan_builder.build_replacement_plan(text, [span], cfg)
+    repl = plan[0].replacement
+    assert repl != src
+    hy_src = [i for i, ch in enumerate(src) if ch == "-"]
+    hy_repl = [i for i, ch in enumerate(repl) if ch == "-"]
+    assert hy_src == hy_repl
+
+
+def test_dob_safe_and_shaped() -> None:
+    cfg = load_config()
+    src = "July 4, 1982"
+    text = f"DOB {src}"
+    s = text.index(src)
+    span = _span(
+        s,
+        s + len(src),
+        src,
+        EntityLabel.DOB,
+        attrs={"format": "month_name_mdY", "normalized": "1982-07-04"},
+    )
+    plan = plan_builder.build_replacement_plan(text, [span], cfg)
+    repl = plan[0].replacement
+    assert repl != src
+    assert re.fullmatch(r"[A-Za-z]+ \d{1,2}, \d{4}", repl)


### PR DESCRIPTION
## Summary
- enforce deterministic safety checks for email, phone, account IDs and DOB replacements
- document bounded retry safety guard in planning
- add focused tests covering email/phone/ID/DOB safety

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=$(pwd)/src:$(pwd) pytest -q` *(fails: libpostal/CLI dependencies missing)*
- `PYTHONPATH=$(pwd)/src:$(pwd)/evaluation pytest tests/test_replace_safety_guard.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5f79bafa88325a4842c1c8644f429