### PR TITLE
feat(address): merge contiguous address lines into ADDRESS_BLOCK

### DIFF
--- a/src/redactor/link/address_merge.py
+++ b/src/redactor/link/address_merge.py
@@ -1,0 +1,167 @@
+"""Merge contiguous address lines into ADDRESS_BLOCK spans.
+
+This module groups adjacent address line spans into multi-line address blocks
+while preserving the original line spans. Blocks are recognised when street or
+PO Box lines are followed by a ``city_state_zip`` line separated by at most one
+blank line. The merged span's ``attrs`` describe each participating line and
+whether a blank line was present.
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_right
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple, cast
+
+from redactor.detect.base import EntityLabel, EntitySpan
+
+__all__ = ["merge_address_lines_into_blocks"]
+
+
+@dataclass(slots=True)
+class _LineInfo:
+    span: EntitySpan
+    line_no: int
+    kind: str
+    start_trim: int
+    end_trim: int
+    text: str
+
+
+def _split_lines(text: str) -> Tuple[List[int], List[Tuple[int, int, str, str]]]:
+    """Return (line_starts, line_info) for ``text``.
+
+    ``line_info`` entries contain ``(start, end_no_eol, line_text, eol)`` where
+    ``line_text`` excludes any end-of-line marker. ``line_starts`` lists the
+    start offset of each line for binary searching.
+    """
+
+    starts: List[int] = []
+    info: List[Tuple[int, int, str, str]] = []
+    pos = 0
+    for raw in text.splitlines(keepends=True):
+        line = raw.rstrip("\r\n")
+        eol = raw[len(line) :]
+        start = pos
+        end_no_eol = start + len(line)
+        starts.append(start)
+        info.append((start, end_no_eol, line, eol))
+        pos += len(raw)
+    return starts, info
+
+
+def _line_for_pos(pos: int, starts: Sequence[int]) -> int:
+    idx = bisect_right(starts, pos) - 1
+    if idx < 0:
+        idx = 0
+    return idx
+
+
+def merge_address_lines_into_blocks(text: str, line_spans: list[EntitySpan]) -> list[EntitySpan]:
+    """Return ``line_spans`` plus merged ADDRESS_BLOCK spans.
+
+    ``line_spans`` must contain per-line address spans as produced by
+    :mod:`redactor.detect.address_libpostal`. Newly created block spans are
+    appended and no original spans are removed.
+    """
+
+    if not line_spans:
+        return []
+
+    starts, line_info = _split_lines(text)
+
+    infos: List[_LineInfo] = []
+    for sp in line_spans:
+        line_no = _line_for_pos(sp.start, starts)
+        start_line, end_no_eol, line_text, _eol = line_info[line_no]
+        left = len(line_text) - len(line_text.lstrip())
+        right = len(line_text.rstrip())
+        start_trim = start_line + left
+        end_trim = start_line + right
+        kind = cast(str, sp.attrs.get("line_kind", ""))
+        infos.append(
+            _LineInfo(
+                span=sp,
+                line_no=line_no,
+                kind=kind,
+                start_trim=start_trim,
+                end_trim=end_trim,
+                text=text[start_trim:end_trim],
+            )
+        )
+
+    infos.sort(key=lambda li: li.line_no)
+
+    candidates: List[Tuple[EntitySpan, set[int]]] = []
+
+    for idx, info in enumerate(infos):
+        if info.kind != "city_state_zip":
+            continue
+        block_lines: List[_LineInfo] = [info]
+        used_lines: set[int] = {info.line_no}
+        had_blank = False
+        line_no = info.line_no
+        j = idx - 1
+        while j >= 0:
+            prev = infos[j]
+            gap = line_no - prev.line_no
+            if gap == 1 and prev.kind in {"street", "unit", "po_box"}:
+                block_lines.insert(0, prev)
+                used_lines.add(prev.line_no)
+                line_no = prev.line_no
+                j -= 1
+                continue
+            if gap == 2 and prev.kind in {"street", "unit", "po_box"}:
+                between = line_info[line_no - 1][2].strip()
+                if not between:
+                    had_blank = True
+                    block_lines.insert(0, prev)
+                    used_lines.add(prev.line_no)
+                    line_no = prev.line_no
+                    j -= 1
+                    continue
+            break
+        if len(block_lines) < 2:
+            continue
+        start = block_lines[0].start_trim
+        end = block_lines[-1].end_trim
+        lines_attr = [
+            {
+                "kind": bl.kind,
+                "text": bl.text,
+                "start": bl.start_trim,
+                "end": bl.end_trim,
+            }
+            for bl in block_lines
+        ]
+        components = cast(dict[str, str], block_lines[-1].span.attrs.get("components", {}))
+        zip_code = components.get("ZipCode", "")
+        zip_kind = "zip9" if len(zip_code.replace("-", "")) > 5 else "zip5" if zip_code else ""
+        confidence = min(0.99, max(bl.span.confidence for bl in block_lines) + 0.01)
+        attrs: dict[str, object] = {
+            "lines": lines_attr,
+            "zip_kind": zip_kind or None,
+            "had_blank_line_between": had_blank,
+            "source_hint": "contiguous_merge_v1",
+        }
+        block_span = EntitySpan(
+            start,
+            end,
+            text[start:end],
+            EntityLabel.ADDRESS_BLOCK,
+            "address_block_merge",
+            confidence,
+            attrs,
+        )
+        candidates.append((block_span, used_lines))
+
+    selected: List[EntitySpan] = []
+    taken: set[int] = set()
+    for span, lines_set in sorted(candidates, key=lambda t: t[0].end - t[0].start, reverse=True):
+        if lines_set.isdisjoint(taken):
+            selected.append(span)
+            taken.update(lines_set)
+
+    result = list(line_spans) + selected
+    result.sort(key=lambda s: s.start)
+    return result

--- a/src/redactor/pseudo/generators/__init__.py
+++ b/src/redactor/pseudo/generators/__init__.py
@@ -1,0 +1,3 @@
+"""Realistic pseudonym generators."""
+
+__all__: list[str] = []

--- a/src/redactor/pseudo/generators/address.py
+++ b/src/redactor/pseudo/generators/address.py
@@ -1,0 +1,118 @@
+"""Deterministic multi-line address replacement generator."""
+
+from __future__ import annotations
+
+import random
+import re
+from typing import List, cast
+
+from ...detect.base import EntitySpan
+from ..generator import PseudonymGenerator
+from .address_data import CITIES, STATE_ABBRS, STREET_NAMES, STREET_TYPES
+
+__all__ = ["generate_address_block_like"]
+
+
+def _random_digits(rng: random.Random, count: int) -> str:
+    return "".join(str(rng.randint(0, 9)) for _ in range(count))
+
+
+def _mutate_like(template: str, rng: random.Random) -> str:
+    out: List[str] = []
+    for ch in template:
+        if ch.isalpha():
+            out.append(rng.choice("ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+        elif ch.isdigit():
+            out.append(str(rng.randint(0, 9)))
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def generate_address_block_like(
+    block: EntitySpan,
+    *,
+    gen: PseudonymGenerator,
+    key: str | None = None,
+) -> str:
+    """Return a fake address block shaped like ``block``."""
+
+    seed_key = key or block.entity_id or f"ADDR:{block.start}-{block.end}"
+    rng = gen.rng("ADDRESS_BLOCK", seed_key)
+
+    line_metas = cast(List[dict[str, object]], block.attrs.get("lines", []))
+    raw_lines = block.text.splitlines(keepends=True)
+    out_lines: List[str] = []
+
+    for idx, meta in enumerate(line_metas):
+        kind = cast(str, meta.get("kind", ""))
+        text_meta = cast(str, meta.get("text", ""))
+        raw = raw_lines[idx] if idx < len(raw_lines) else ""
+        if raw.endswith("\r\n"):
+            eol = "\r\n"
+            body = raw[:-2]
+        elif raw.endswith("\n"):
+            eol = "\n"
+            body = raw[:-1]
+        else:
+            eol = ""
+            body = raw
+
+        if kind == "po_box":
+            prefix = text_meta.split()[0:2]
+            prefix_text = " ".join(prefix)
+            number = int(_random_digits(rng, rng.randint(3, 5)))
+            line = f"{prefix_text} {number}"
+        elif kind == "street":
+            unit_match = re.search(r"\b(Apt|Ste|Suite|Unit|#)\b", text_meta, re.IGNORECASE)
+            number = rng.randint(100, 9999)
+            street = rng.choice(STREET_NAMES)
+            stype = rng.choice(STREET_TYPES)
+            core = f"{number} {street} {stype}"
+            if unit_match:
+                keyword = unit_match.group(0)
+                unit_tail = text_meta[unit_match.end() :].strip()
+                ident = _mutate_like(unit_tail, rng)
+                line = f"{core} {keyword} {ident}".rstrip()
+            else:
+                line = core
+        elif kind == "unit":
+            m = re.match(r"\s*(Apt|Ste|Suite|Unit|#)\b", text_meta, re.IGNORECASE)
+            keyword = m.group(1) if m else "Apt"
+            ident = text_meta[m.end() :].strip() if m else text_meta.strip()
+            ident = _mutate_like(ident, rng)
+            line = f"{keyword} {ident}".strip()
+        elif kind == "city_state_zip":
+            zip_kind = cast(str | None, block.attrs.get("zip_kind"))
+            city = rng.choice(CITIES)
+            state = rng.choice(STATE_ABBRS)
+            zip_code = f"{rng.randint(0, 99999):05d}"
+            if zip_kind == "zip9":
+                zip_code = f"{zip_code}-{rng.randint(0, 9999):04d}"
+            if "," in body:
+                comma_pos = body.find(",")
+                after = body[comma_pos + 1 :]
+                spaces = len(after) - len(after.lstrip(" "))
+                after = after.lstrip(" ")
+                state_sep = after[2:]
+                spaces2 = len(state_sep) - len(state_sep.lstrip(" "))
+                sep1 = "," + " " * spaces
+                sep2 = " " * spaces2
+                line = f"{city}{sep1}{state}{sep2}{zip_code}".rstrip()
+            else:
+                parts = body.split()
+                sep2 = " "
+                if len(parts) > 2:
+                    sep2 = body[body.find(parts[1]) + len(parts[1]) : body.find(parts[2])]
+                line = f"{city} {state}{sep2}{zip_code}".rstrip()
+        else:
+            line = body
+
+        if len(line) > 120:
+            line = line[:120]
+        assert "Acct_" not in line and "ACCT_" not in line
+        out_lines.append(line + eol)
+
+    result = "".join(out_lines)
+    assert "Acct_" not in result and "ACCT_" not in result
+    return result

--- a/src/redactor/pseudo/generators/address_data.py
+++ b/src/redactor/pseudo/generators/address_data.py
@@ -1,0 +1,86 @@
+"""Small static corpora for address generation."""
+
+from __future__ import annotations
+
+STREET_TYPES = ["St", "Ave", "Rd", "Blvd", "Ln"]
+
+STREET_NAMES = [
+    "Oak",
+    "Maple",
+    "Pine",
+    "Cedar",
+    "Elm",
+    "Walnut",
+    "Willow",
+    "Birch",
+    "Chestnut",
+    "Ash",
+]
+
+CITIES = [
+    "Springfield",
+    "Fairview",
+    "Riverton",
+    "Greenville",
+    "Madison",
+    "Georgetown",
+    "Clinton",
+    "Bristol",
+    "Dayton",
+    "Kingston",
+]
+
+STATE_ABBRS = [
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DE",
+    "FL",
+    "GA",
+    "HI",
+    "IA",
+    "ID",
+    "IL",
+    "IN",
+    "KS",
+    "KY",
+    "LA",
+    "MA",
+    "MD",
+    "ME",
+    "MI",
+    "MN",
+    "MO",
+    "MS",
+    "MT",
+    "NC",
+    "ND",
+    "NE",
+    "NH",
+    "NJ",
+    "NM",
+    "NV",
+    "NY",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VA",
+    "VT",
+    "WA",
+    "WI",
+    "WV",
+    "WY",
+]
+
+__all__ = ["STREET_TYPES", "STREET_NAMES", "CITIES", "STATE_ABBRS"]

--- a/src/redactor/verify/scanner.py
+++ b/src/redactor/verify/scanner.py
@@ -139,7 +139,7 @@ def scan_text(
         for pe in applied_plan:
             if pe.label is EntityLabel.ADDRESS_BLOCK:
                 for line in pe.replacement.splitlines():
-                    stripped = line.strip()
+                    stripped = line.rstrip()
                     if stripped:
                         block_lines.add(stripped)
     residual: list[VerificationFinding] = []
@@ -159,14 +159,14 @@ def scan_text(
         if counter and counter[f.text] > 0:
             counter[f.text] -= 1
             reason = "replacement_match"
-        elif label is EntityLabel.ADDRESS_BLOCK and f.text.strip() in block_lines:
+        elif label is EntityLabel.ADDRESS_BLOCK and f.text.rstrip() in block_lines:
             reason = "replacement_match_block_line"
         elif label in {EntityLabel.GPE, EntityLabel.LOC}:
             line_start = text.rfind("\n", 0, f.start) + 1
             line_end = text.find("\n", f.end)
             if line_end == -1:
                 line_end = len(text)
-            line_text = text[line_start:line_end].strip()
+            line_text = text[line_start:line_end].rstrip()
             if line_text in block_lines:
                 reason = "in_address_block_replacement"
         elif label is EntityLabel.EMAIL:

--- a/tests/test_address_block_merge.py
+++ b/tests/test_address_block_merge.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from redactor.detect.address_libpostal import AddressLineDetector
+from redactor.detect.base import EntityLabel, EntitySpan
+from redactor.link.address_merge import merge_address_lines_into_blocks
+
+
+def _detect_lines(text: str) -> list[EntitySpan]:
+    det = AddressLineDetector()
+    try:
+        spans = det.detect(text)
+    except RuntimeError:
+        pytest.skip("usaddress library not available")
+    return [sp for sp in spans if sp.label is EntityLabel.ADDRESS_BLOCK]
+
+
+def test_merge_two_lines() -> None:
+    text = "366 Broadway\nCambridge, MA 02139\n"
+    lines = _detect_lines(text)
+    merged = merge_address_lines_into_blocks(text, lines)
+    blocks = [sp for sp in merged if sp.source == "address_block_merge"]
+    assert len(blocks) == 1
+    block = blocks[0]
+    assert block.text.count("\n") == 1
+    lines_attr = cast(list[dict[str, object]], block.attrs["lines"])
+    kinds = [line["kind"] for line in lines_attr]
+    assert kinds == ["street", "city_state_zip"]
+
+
+def test_merge_po_box() -> None:
+    text = "PO Box 123\nCambridge, MA 02139"
+    lines = _detect_lines(text)
+    merged = merge_address_lines_into_blocks(text, lines)
+    block = [sp for sp in merged if sp.source == "address_block_merge"][0]
+    lines_attr = cast(list[dict[str, object]], block.attrs["lines"])
+    kinds = [line["kind"] for line in lines_attr]
+    assert kinds[0] == "po_box"
+
+
+def test_merge_with_unit() -> None:
+    text = "366 Broadway Apt 5B\nCambridge, MA 02139"
+    lines = _detect_lines(text)
+    merged = merge_address_lines_into_blocks(text, lines)
+    block = [sp for sp in merged if sp.source == "address_block_merge"][0]
+    lines_attr = cast(list[dict[str, object]], block.attrs["lines"])
+    kinds = [line["kind"] for line in lines_attr]
+    assert kinds[-1] == "city_state_zip"
+    assert kinds[0] in {"street", "unit"}
+
+
+def test_no_merge_far_apart() -> None:
+    text = "366 Broadway\n\nSee you soon\nCambridge, MA 02139"
+    lines = _detect_lines(text)
+    merged = merge_address_lines_into_blocks(text, lines)
+    blocks = [sp for sp in merged if sp.source == "address_block_merge"]
+    assert not blocks
+    assert len(merged) == len(lines)

--- a/tests/test_address_block_replace.py
+++ b/tests/test_address_block_replace.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+import pytest
+
+from redactor.config import load_config
+from redactor.detect.address_libpostal import AddressLineDetector
+from redactor.detect.base import EntityLabel
+from redactor.link import span_merger
+from redactor.link.address_merge import merge_address_lines_into_blocks
+from redactor.replace.applier import apply_plan
+from redactor.replace.plan_builder import PlanEntry, build_replacement_plan
+from redactor.verify import scanner
+
+
+def _pipeline(text: str) -> Tuple[str, list[PlanEntry]]:
+    cfg = load_config()
+    det = AddressLineDetector()
+    try:
+        lines = det.detect(text)
+    except RuntimeError:
+        pytest.skip("usaddress library not available")
+    addr_lines = [sp for sp in lines if sp.label is EntityLabel.ADDRESS_BLOCK]
+    merged = merge_address_lines_into_blocks(text, addr_lines)
+    merged_spans = span_merger.merge_spans(merged, cfg)
+    plan = build_replacement_plan(text, merged_spans, cfg)
+    return apply_plan(text, plan)
+
+
+def test_replacement_shape_two_lines() -> None:
+    text = "366 Broadway\nCambridge, MA 02139\n"
+    redacted, plan = _pipeline(text)
+    pe = plan[0]
+    assert pe.replacement.count("\n") == 1
+    assert "Broadway" not in pe.replacement
+    assert "Cambridge, MA 02139" not in pe.replacement
+    assert re.search(r"\b\d{5}(?:-\d{4})?\b", pe.replacement)
+
+
+def test_preserve_unit_keyword() -> None:
+    text = "366 Broadway Apt 5B\nCambridge, MA 02139"
+    redacted, plan = _pipeline(text)
+    first_line = plan[0].replacement.splitlines()[0]
+    assert re.search(r"\b(Apt|Ste|Suite|Unit|#)\b", first_line)
+
+
+def test_verifier_ignores_replacement_lines() -> None:
+    text = "366 Broadway\nCambridge, MA 02139"
+    redacted, plan = _pipeline(text)
+    report = scanner.scan_text(redacted, load_config(), applied_plan=plan)
+    assert report.residual_count == 0
+    reasons = {f.ignored_reason for f in report.ignored}
+    assert "replacement_match_block_line" in reasons
+    assert "in_address_block_replacement" in reasons
+
+
+def test_mixed_eols() -> None:
+    text = "366 Broadway\r\nCambridge, MA 02139"
+    redacted, plan = _pipeline(text)
+    assert "\r\n" in plan[0].replacement


### PR DESCRIPTION
## Summary
- merge adjacent address lines into ADDRESS_BLOCK spans
- add deterministic multi-line US address generator
- ignore replacement address lines during verification

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src:. pytest -q` *(fails: ModuleNotFoundError: usaddress not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6de243e008325bfdf44cb94541f90