### PR TITLE
feat(replace): deterministic safety guard and audit polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Legal alias labels (e.g., `hereinafter`, `a/k/a`, `d/b/a`) are detected as `ALIA
 
 Plan entries hold exact `[start,end)` ranges and their replacements. We perform bounded safety checks at plan time to coerce risky candidates into safe shapes (emails → `example.org`, phones → `555` patterns, IDs with checksums or non‑colliding digits). Application is reverse, chunked, validated, and idempotent.
 
+Safety is enforced *by construction*: unsafe candidates are rejected and
+deterministically regenerated with salted keys up to two times.  Retry counts
+and reasons are recorded in the audit summary for traceability.
+
 
 
 ## Verification & Leakage Scoring

--- a/src/redactor/pseudo/generators/__init__.py
+++ b/src/redactor/pseudo/generators/__init__.py
@@ -1,3 +1,3 @@
 """Realistic pseudonym generators."""
 
-__all__: list[str] = []
+__all__ = ["address", "email", "phone", "numbers"]

--- a/src/redactor/pseudo/generators/email.py
+++ b/src/redactor/pseudo/generators/email.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Email pseudonym helpers.
+
+These helpers render deterministic placeholder emails while preserving the
+visible shape of the local part.  Domains are always coerced to
+``example.org`` to avoid accidentally generating a real address.
+"""
+
+from redactor.pseudo.generator import PseudonymGenerator
+
+__all__ = ["generate_email_like"]
+
+
+def generate_email_like(source: str, *, key: str, gen: PseudonymGenerator) -> str:
+    """Return an email shaped like ``source`` using ``example.org`` domain."""
+
+    local_src, _, _domain = source.partition("@")
+    base, plus, tag = local_src.partition("+")
+    length = len(base)
+    token = gen.token("EMAIL", key, length=length or 1)
+    safe_base = token[:length] if length else token
+    local = safe_base
+    if plus:
+        local += "+" + tag
+    return f"{local}@example.org"

--- a/src/redactor/pseudo/generators/numbers.py
+++ b/src/redactor/pseudo/generators/numbers.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Numeric identifier pseudonym helpers."""
+
+from redactor.pseudo import number_rules
+from redactor.pseudo.generator import PseudonymGenerator
+
+__all__ = [
+    "generate_cc_like",
+    "generate_generic_digits_like",
+    "generate_routing_like",
+    "generate_iban_like",
+    "generate_ein_like",
+    "generate_ssn_like",
+]
+
+
+def generate_cc_like(
+    source: str, *, key: str, gen: PseudonymGenerator
+) -> str:  # pragma: no cover - wrapper
+    return number_rules.generate_cc_like(source, key=key, gen=gen)
+
+
+def generate_generic_digits_like(
+    source: str, *, key: str, gen: PseudonymGenerator
+) -> str:  # pragma: no cover
+    return number_rules.generate_generic_digits_like(source, key=key, gen=gen)
+
+
+def generate_routing_like(
+    source: str, *, key: str, gen: PseudonymGenerator
+) -> str:  # pragma: no cover
+    return number_rules.generate_routing_like(source, key=key, gen=gen)
+
+
+def generate_iban_like(
+    source: str, *, key: str, gen: PseudonymGenerator
+) -> str:  # pragma: no cover
+    return number_rules.generate_iban_like(source, key=key, gen=gen)
+
+
+def generate_ein_like(source: str, *, key: str, gen: PseudonymGenerator) -> str:  # pragma: no cover
+    return number_rules.generate_ein_like(source, key=key, gen=gen)
+
+
+def generate_ssn_like(source: str, *, key: str, gen: PseudonymGenerator) -> str:  # pragma: no cover
+    return number_rules.generate_ssn_like(source, key=key, gen=gen)

--- a/src/redactor/pseudo/generators/phone.py
+++ b/src/redactor/pseudo/generators/phone.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Phone number pseudonym helpers."""
+
+import re
+from redactor.pseudo.generator import PseudonymGenerator
+
+__all__ = ["generate_phone_like"]
+
+
+def _format_digits_like(source: str, digits: str) -> str:
+    it = iter(digits)
+    out: list[str] = []
+    for ch in source:
+        if ch.isdigit():
+            out.append(next(it, "0"))
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def generate_phone_like(source: str, *, key: str, gen: PseudonymGenerator) -> str:
+    """Return a phone number shaped like ``source`` with a safe 555 exchange."""
+
+    digits = re.sub(r"\D", "", source)
+    rng = gen.rng("SAFE_PHONE", key)
+    line = rng.randint(0, 9999)
+    if source.strip().startswith("+"):
+        new_digits = f"1555{line:04d}"
+        return "+" + _format_digits_like(source[1:], new_digits)
+    area = digits[:3] if len(digits) >= 10 else f"{rng.randint(200,999):03d}"
+    new_digits = f"{area}555{line:04d}"
+    return _format_digits_like(source, new_digits)

--- a/tests/test_audit_report.py
+++ b/tests/test_audit_report.py
@@ -69,7 +69,9 @@ def test_audit_workflow(tmp_path: Path) -> None:
     assert entries[2].label is EntityLabel.EMAIL
 
     cfg = load_config(env={"REDACTOR_SEED_SECRET": "s3cret"})
-    summary, verification_dict = summarize_audit(before, entries, cfg=cfg, verification_report=None)
+    summary, verification_dict = summarize_audit(
+        before, entries, cfg=cfg, plan=plan, verification_report=None
+    )
     assert summary.total_replacements == 3
     assert summary.counts_by_label == {"PERSON": 1, "ALIAS_LABEL": 1, "EMAIL": 1}
     assert summary.deltas_total == sum(e.length_delta for e in entries)
@@ -78,7 +80,9 @@ def test_audit_workflow(tmp_path: Path) -> None:
     assert verification_dict is None
 
     cfg_no = load_config(env={})
-    summary_no, _ = summarize_audit(before, entries, cfg=cfg_no, verification_report=None)
+    summary_no, _ = summarize_audit(
+        before, entries, cfg=cfg_no, plan=plan, verification_report=None
+    )
     assert summary_no.seed_present is False
     summary_json = json.dumps(asdict(summary))
     assert "s3cret" not in summary_json
@@ -127,13 +131,15 @@ def test_seed_presence_signal() -> None:
     entries = build_audit_entries(before, after, plan)
 
     cfg = load_config(env={"REDACTOR_SEED_SECRET": "unit-test-secret"})
-    summary, _ = summarize_audit(before, entries, cfg=cfg, verification_report=None)
+    summary, _ = summarize_audit(before, entries, cfg=cfg, plan=plan, verification_report=None)
     assert summary.seed_present is True
     summary_json = json.dumps(asdict(summary))
     assert "unit-test-secret" not in summary_json
 
     cfg_no = load_config(env={})
-    summary_no, _ = summarize_audit(before, entries, cfg=cfg_no, verification_report=None)
+    summary_no, _ = summarize_audit(
+        before, entries, cfg=cfg_no, plan=plan, verification_report=None
+    )
     assert summary_no.seed_present is False
 
 

--- a/tests/test_replace_case_format.py
+++ b/tests/test_replace_case_format.py
@@ -1,0 +1,46 @@
+import re
+from typing import Dict
+
+from redactor.config import load_config
+from redactor.detect.base import EntityLabel, EntitySpan
+from redactor.replace import plan_builder
+
+
+def _span(
+    start: int,
+    end: int,
+    text: str,
+    label: EntityLabel,
+    *,
+    attrs: Dict[str, object] | None = None,
+) -> EntitySpan:
+    return EntitySpan(start, end, text, label, "t", 0.9, attrs or {})
+
+
+def test_name_case_and_initials() -> None:
+    cfg = load_config()
+    text = "JOHN DOE met J. D. Salinger."
+    spans = [
+        _span(0, 8, "JOHN DOE", EntityLabel.PERSON),
+        _span(13, 27, "J. D. Salinger", EntityLabel.PERSON),
+    ]
+    plan = plan_builder.build_replacement_plan(text, spans, cfg)
+    repls = [p.replacement for p in plan]
+    assert repls[0].isupper()
+    assert re.fullmatch(r"[A-Z]\. [A-Z]\. [A-Za-z]+", repls[1])
+
+
+def test_date_and_phone_format() -> None:
+    cfg = load_config()
+    text = "DOB1: July 4, 1982; DOB2: 12/21/1975; Phone: (415) 867-5309"
+    spans = [
+        _span(6, 17, "July 4, 1982", EntityLabel.DOB, attrs={"normalized": "1982-07-04"}),
+        _span(25, 35, "12/21/1975", EntityLabel.DOB, attrs={"normalized": "1975-12-21"}),
+        _span(45, 59, "(415) 867-5309", EntityLabel.PHONE),
+    ]
+    plan = plan_builder.build_replacement_plan(text, spans, cfg)
+    dob_repls = [p.replacement for p in plan if p.label is EntityLabel.DOB]
+    phone_repl = next(p.replacement for p in plan if p.label is EntityLabel.PHONE)
+    assert re.fullmatch(r"[A-Za-z]+ \d{1,2}, \d{4}", dob_repls[0])
+    assert re.fullmatch(r"\d{2}/\d{2}/\d{4}", dob_repls[1])
+    assert re.sub(r"\d", "0", phone_repl) == "(000) 000-0000"


### PR DESCRIPTION
## Summary
- add bounded safety guard for emails, phones, account IDs and DOB
- preserve name initials and casing, forbid non-account `Acct_` tokens
- track safety retries in plan metadata and audit summaries

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest tests/test_replace_safety_guard.py tests/test_replace_case_format.py -q`
- `pytest -q` *(fails: Module `usaddress` missing, address tests error)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e21ecba88325be6aa5b9908537bc